### PR TITLE
fix(frontend): restaura envio de interesses no cadastro de estudante

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -272,6 +272,7 @@ class OrganizationRegistrationSerializer(serializers.Serializer):
             username=username,
             nome=validated_data.get("nome_fantasia") or validated_data["razao_social"],
             role=User.Role.ORGANIZACAO,
+            is_active=False,
         )
         user.set_password(password)
         user.save()

--- a/backend/users/tests/test_views.py
+++ b/backend/users/tests/test_views.py
@@ -368,6 +368,9 @@ class TestOrganizationRegisterEndpoint:
 
     def test_register_organization_success(self, api_client):
         """Registro valido retorna HTTP 201."""
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        
         response = api_client.post(self.ENDPOINT, _organization_payload(), format="json")
         print("RESPONSE DATA:", response.json())
         assert response.status_code == 201
@@ -377,8 +380,10 @@ class TestOrganizationRegisterEndpoint:
         assert "organization_profile" in data
         assert data["organization_profile"]["cnpj"] == "52210871000133"
         assert data["organization_profile"]["status"] == "pending"
-        assert "tokens" in data
-        assert "access" in data["tokens"]
+        assert "tokens" not in data
+        
+        user = User.objects.get(email="org@teste.com")
+        assert user.is_active is False
 
     def test_register_organization_invalid_cnpj(self, api_client):
         """CNPJ invalido retorna HTTP 400."""

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -148,9 +148,6 @@ def organization_register(request):
     except Exception:
         return Response({"detail": "Erro interno do servidor."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    # Gera os tokens JWT
-    refresh = RefreshToken.for_user(user)
-
     # Constrói os dados do profile
     profile_data = OrganizationProfileSerializer(user.organization_profile).data
 
@@ -160,10 +157,6 @@ def organization_register(request):
         "nome": user.nome,
         "role": user.role,
         "organization_profile": profile_data,
-        "tokens": {
-            "access": str(refresh.access_token),
-            "refresh": str(refresh),
-        },
     }
 
     return Response(data, status=status.HTTP_201_CREATED)

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -216,7 +216,6 @@ describe('AuthContext', () => {
       email: 'ong@example.com',
       nome: 'ONG Test',
       role: 'organizacao',
-      tokens: { access: 'org-access-token', refresh: 'org-refresh-token' },
       organization_profile: {
         cnpj: '12.345.678/0001-90',
         razao_social: 'ONG Test',

--- a/frontend/src/screens/auth/RegisterScreen.test.tsx
+++ b/frontend/src/screens/auth/RegisterScreen.test.tsx
@@ -208,6 +208,9 @@ describe('RegisterScreen', () => {
       expect(screen.getByText('Criar minha conta')).toBeTruthy();
     });
 
+    fireEvent.press(screen.getByText('Meio Ambiente'));
+    fireEvent.press(screen.getByText('Tecnologia'));
+
     fireEvent.press(screen.getByText('Criar minha conta'));
 
     await waitFor(() => {
@@ -217,6 +220,7 @@ describe('RegisterScreen', () => {
           nome: expect.stringContaining('Ana'),
           curso: 'Eng. Software',
           matricula: '20231234567',
+          interesses: ['meio_ambiente', 'tecnologia'],
         }),
       );
     });

--- a/frontend/src/screens/auth/RegisterScreen.tsx
+++ b/frontend/src/screens/auth/RegisterScreen.tsx
@@ -136,6 +136,7 @@ export default function RegisterScreen() {
         turno: (finalData.turno as any) ?? null,
         ano_conclusao: finalData.ano_conclusao ?? null,
         horas_extensao_exigidas: finalData.horas_extensao_exigidas ?? null,
+        interesses: finalData.interesses ?? [],
       });
     } catch (error) {
       const fieldErrors = extractFieldErrors(error);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -59,10 +59,6 @@ export type OrganizationRegisterResponse = {
     nome_responsavel: string;
     status: string;
   };
-  tokens: {
-    access: string;
-    refresh: string;
-  };
 };
 
 export class ApiError extends Error {


### PR DESCRIPTION
Refs #61: Adiciona teste e corrige o envio do campo interesses no RegisterScreen.

Refs #62: Organizações agora nascem inativas e não recebem JWT na resposta.