### PR TITLE
feat(auth): persistência de tokens JWT e fluxo completo de login

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -24,6 +24,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-secure-store"
+    ]
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,8 @@
         "@react-navigation/native": "^7.2.4",
         "@react-navigation/native-stack": "^7.15.0",
         "expo": "~54.0.33",
+        "expo-image-picker": "~17.0.11",
+        "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4356,7 +4358,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5781,7 +5783,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6457,6 +6459,42 @@
         }
       }
     },
+    "node_modules/expo-font": {
+      "version": "56.0.5",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-56.0.5.tgz",
+      "integrity": "sha512-WLoDu9hlEgPRKXJRR01HFLJ6Z2tFcORX/WFPRYBndmYc5kjQrFGH/j4BRaF3aBRPyYEAUXiUJybNLXkKCwEXQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.11.tgz",
+      "integrity": "sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.25",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.25.tgz",
@@ -6554,6 +6592,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {
@@ -13504,7 +13551,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,8 @@
     "@react-navigation/native": "^7.2.4",
     "@react-navigation/native-stack": "^7.15.0",
     "expo": "~54.0.33",
+    "expo-image-picker": "~17.0.11",
+    "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
 
 import { AuthProvider, useAuth } from './AuthContext';
 
@@ -8,6 +9,15 @@ import { AuthProvider, useAuth } from './AuthContext';
 jest.mock('../services/api', () => ({
   studentRegister: jest.fn(),
   organizationRegister: jest.fn(),
+  login: jest.fn(),
+  fetchWithAuth: jest.fn(),
+}));
+
+// Mock expo-secure-store
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
 }));
 
 // Componente auxiliar para testar o hook
@@ -81,22 +91,26 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('auth-state').props.children).toBe('unauthenticated');
   });
 
-  it('provides no user in default state', () => {
+  it('provides no user in default state', async () => {
     render(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>,
     );
-    expect(screen.getByTestId('user-state').props.children).toBe('no-user');
+    await waitFor(() => {
+      expect(screen.getByTestId('user-state').props.children).toBe('no-user');
+    });
   });
 
-  it('provides isLoading as false initially', () => {
+  it('provides isLoading as false after hydration completes', async () => {
     render(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>,
     );
-    expect(screen.getByTestId('loading-state').props.children).toBe('not-loading');
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-state').props.children).toBe('not-loading');
+    });
   });
 
   it('calls API and updates state after register', async () => {
@@ -245,5 +259,288 @@ describe('AuthContext', () => {
 
     expect(screen.getByTestId('auth-state').props.children).toBe('unauthenticated');
     expect(screen.getByTestId('user-state').props.children).toBe('no-user');
+  });
+
+  // ─── T1.6: handleLogin tests ───
+
+  function LoginConsumer({ onLoginDone }: { onLoginDone: () => void }) {
+    const { handleLogin } = useAuth();
+    return (
+      <Text
+        testID="login-btn"
+        onPress={async () => {
+          await handleLogin('maria@email.edu.br', 'Senha123');
+          onLoginDone();
+        }}
+      >
+        Login
+      </Text>
+    );
+  }
+
+  it('calls api.login and updates state after successful login', async () => {
+    const { login } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'access-token-login',
+      refresh: 'refresh-token-login',
+      role: 'estudante',
+      nome: 'Maria Silva',
+      id: 'uuid-maria',
+    });
+
+    const onLoginDone = jest.fn();
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+        <LoginConsumer onLoginDone={onLoginDone} />
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalledWith({ email: 'maria@email.edu.br', password: 'Senha123' });
+    });
+  });
+
+  it('sets isAuthenticated to true after successful login', async () => {
+    const { login } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'access-token',
+      refresh: 'refresh-token',
+      role: 'estudante',
+      nome: 'Maria Silva',
+      id: 'uuid-maria',
+    });
+
+    const onLoginDone = jest.fn();
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+        <LoginConsumer onLoginDone={onLoginDone} />
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state').props.children).toBe('authenticated');
+    });
+  });
+
+  it('stores user data after successful login', async () => {
+    const { login } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'access-token',
+      refresh: 'refresh-token',
+      role: 'estudante',
+      nome: 'Maria Silva',
+      id: 'uuid-maria',
+    });
+
+    const onLoginDone = jest.fn();
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+        <LoginConsumer onLoginDone={onLoginDone} />
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-state').props.children).toBe('maria@email.edu.br');
+    });
+  });
+
+  it('persists tokens to SecureStore on login', async () => {
+    const { login } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'access-token-ss',
+      refresh: 'refresh-token-ss',
+      role: 'estudante',
+      nome: 'Maria',
+      id: 'uuid-maria',
+    });
+
+    const onLoginDone = jest.fn();
+    (SecureStore.setItemAsync as jest.Mock).mockClear();
+
+    render(
+      <AuthProvider>
+        <LoginConsumer onLoginDone={onLoginDone} />
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'auth_access_token',
+        'access-token-ss',
+      );
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'auth_refresh_token',
+        'refresh-token-ss',
+      );
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'auth_user',
+        expect.stringContaining('Maria'),
+      );
+    });
+  });
+
+  // ─── T1.7: Token persistence / hydration tests ───
+
+  it('hydrates session from SecureStore on mount', async () => {
+    const storedUser = JSON.stringify({
+      id: 'hydrated-id',
+      email: 'hydrated@test.com',
+      nome: 'Hydrated User',
+      role: 'estudante',
+    });
+
+    (SecureStore.getItemAsync as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'auth_access_token') return Promise.resolve('hydrated-access');
+      if (key === 'auth_refresh_token') return Promise.resolve('hydrated-refresh');
+      if (key === 'auth_user') return Promise.resolve(storedUser);
+      return Promise.resolve(null);
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state').props.children).toBe('authenticated');
+    });
+
+    expect(screen.getByTestId('user-state').props.children).toBe('hydrated@test.com');
+  });
+
+  // ─── T1.8: authenticatedFetch tests ───
+
+  function FetchConsumer({ onFetch }: { onFetch: () => void }) {
+    const { authenticatedFetch } = useAuth();
+    return (
+      <Text
+        testID="fetch-btn"
+        onPress={async () => {
+          await authenticatedFetch('https://api.test/endpoint');
+          onFetch();
+        }}
+      >
+        Fetch
+      </Text>
+    );
+  }
+
+  it('authenticatedFetch calls fetchWithAuth with the access token', async () => {
+    // Ensure SecureStore returns null so hydration doesn't set a stale token
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+
+    const { login, fetchWithAuth } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'fetch-token',
+      refresh: 'refresh-token',
+      role: 'estudante',
+      nome: 'Fetch User',
+      id: 'uuid-fetch',
+    });
+    fetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+
+    const onLoginDone = jest.fn();
+    const onFetch = jest.fn();
+
+    render(
+      <AuthProvider>
+        <LoginConsumer onLoginDone={onLoginDone} />
+        <FetchConsumer onFetch={onFetch} />
+      </AuthProvider>,
+    );
+
+    // First login
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalled();
+    });
+
+    // Then fetch
+    await act(async () => {
+      screen.getByTestId('fetch-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        'https://api.test/endpoint',
+        'fetch-token',
+        {},
+      );
+    });
+  });
+
+  // ─── Logout tests ───
+
+  it('clears SecureStore on logout', async () => {
+    const { login } = require('../services/api');
+    login.mockResolvedValueOnce({
+      access: 'token-to-clear',
+      refresh: 'refresh-to-clear',
+      role: 'estudante',
+      nome: 'Clear Me',
+      id: 'uuid-clear',
+    });
+
+    const onLoginDone = jest.fn();
+
+    function LogoutConsumer() {
+      const { logout } = useAuth();
+      return <Text testID="logout-btn" onPress={() => logout()}>Logout</Text>;
+    }
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+        <LoginConsumer onLoginDone={onLoginDone} />
+        <LogoutConsumer />
+      </AuthProvider>,
+    );
+
+    // Login first
+    await act(async () => {
+      screen.getByTestId('login-btn').props.onPress();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state').props.children).toBe('authenticated');
+    });
+
+    (SecureStore.deleteItemAsync as jest.Mock).mockClear();
+
+    // Logout
+    await act(async () => {
+      screen.getByTestId('logout-btn').props.onPress();
+    });
+
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_access_token');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_refresh_token');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_user');
+    expect(screen.getByTestId('auth-state').props.children).toBe('unauthenticated');
   });
 });

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
 
 import {
   StudentRegisterPayload,
@@ -7,6 +8,10 @@ import {
   OrganizationRegisterPayload,
   OrganizationRegisterResponse,
   organizationRegister,
+  login,
+  LoginPayload,
+  fetchWithAuth,
+  refreshAccessToken,
 } from '../services/api';
 
 export interface AuthUser {
@@ -16,6 +21,12 @@ export interface AuthUser {
   role: string;
 }
 
+const SECURE_STORE_KEYS = {
+  accessToken: 'auth_access_token',
+  refreshToken: 'auth_refresh_token',
+  user: 'auth_user',
+} as const;
+
 interface AuthContextValue {
   isAuthenticated: boolean;
   isLoading: boolean;
@@ -24,6 +35,9 @@ interface AuthContextValue {
   refreshToken: string | null;
   studentRegister: (payload: StudentRegisterPayload) => Promise<StudentRegisterResponse>;
   organizationRegister: (payload: OrganizationRegisterPayload) => Promise<OrganizationRegisterResponse>;
+  handleLogin: (email: string, password: string) => Promise<void>;
+  authenticatedFetch: (url: string, options?: RequestInit) => Promise<Response>;
+  tryRefreshSession: () => Promise<string | null>;
   logout: () => void;
 }
 
@@ -34,19 +48,49 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // T1.7: Hydrate session from SecureStore on app init
+  useEffect(() => {
+    async function hydrate() {
+      try {
+        const storedToken = await SecureStore.getItemAsync(SECURE_STORE_KEYS.accessToken);
+        const storedRefresh = await SecureStore.getItemAsync(SECURE_STORE_KEYS.refreshToken);
+        const storedUser = await SecureStore.getItemAsync(SECURE_STORE_KEYS.user);
+
+        if (storedToken && storedUser) {
+          setAccessToken(storedToken);
+          setRefreshToken(storedRefresh);
+          setUser(JSON.parse(storedUser));
+        }
+      } catch {
+        // If reading fails, stay logged out — tokens may be corrupted or unavailable
+      } finally {
+        setIsHydrated(true);
+      }
+    }
+    hydrate();
+  }, []);
 
   async function handleStudentRegister(payload: StudentRegisterPayload): Promise<StudentRegisterResponse> {
     setIsLoading(true);
     try {
       const response = await studentRegister(payload);
-      setUser({
+      const authUser: AuthUser = {
         id: response.id,
         email: response.email,
         nome: response.nome,
         role: response.role,
-      });
+      };
+      setUser(authUser);
       setAccessToken(response.tokens.access);
       setRefreshToken(response.tokens.refresh);
+
+      // Persist to SecureStore
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.accessToken, response.tokens.access);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.refreshToken, response.tokens.refresh);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.user, JSON.stringify(authUser));
+
       return response;
     } finally {
       setIsLoading(false);
@@ -57,28 +101,101 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(true);
     try {
       const response = await organizationRegister(payload);
-      // Removed auto-login (setUser, setAccessToken, setRefreshToken) 
-      // because organizations are created with 'pending' status and require approval.
+      // Organizations start as 'pending' — no auto-login
       return response;
     } finally {
       setIsLoading(false);
     }
   }
 
-  function logout() {
+  // T1.6: handleLogin — calls api.login(), stores user + tokens in state AND SecureStore
+  async function handleLogin(email: string, password: string): Promise<void> {
+    setIsLoading(true);
+    try {
+      const payload: LoginPayload = { email, password };
+      const response = await login(payload);
+
+      const authUser: AuthUser = {
+        id: response.id,
+        email,
+        nome: response.nome,
+        role: response.role,
+      };
+
+      setUser(authUser);
+      setAccessToken(response.access);
+      setRefreshToken(response.refresh);
+
+      // Persist to SecureStore
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.accessToken, response.access);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.refreshToken, response.refresh);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.user, JSON.stringify(authUser));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  // T1.8: authenticated fetch helper exposed from context
+  async function authenticatedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+    if (!accessToken) {
+      throw new Error('No access token available. User must be logged in.');
+    }
+    return fetchWithAuth(url, accessToken, options);
+  }
+
+  /**
+   * Attempt to refresh the access token using the stored refresh token.
+   * On success: updates state + SecureStore with new tokens, returns new access token.
+   * On failure: logs out (clears session entirely), returns null.
+   *
+   * Callers should check the return value — if null, navigation will
+   * automatically redirect to AuthStack because isAuthenticated becomes false.
+   */
+  async function tryRefreshSession(): Promise<string | null> {
+    if (!refreshToken) {
+      await logout();
+      return null;
+    }
+    try {
+      const result = await refreshAccessToken(refreshToken);
+      setAccessToken(result.access);
+      setRefreshToken(result.refresh);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.accessToken, result.access);
+      await SecureStore.setItemAsync(SECURE_STORE_KEYS.refreshToken, result.refresh);
+      return result.access;
+    } catch {
+      // Refresh failed — token is expired/invalid, force re-login
+      await logout();
+      return null;
+    }
+  }
+
+  async function logout(): Promise<void> {
     setUser(null);
     setAccessToken(null);
     setRefreshToken(null);
+
+    // Clear SecureStore
+    try {
+      await SecureStore.deleteItemAsync(SECURE_STORE_KEYS.accessToken);
+      await SecureStore.deleteItemAsync(SECURE_STORE_KEYS.refreshToken);
+      await SecureStore.deleteItemAsync(SECURE_STORE_KEYS.user);
+    } catch {
+      // If deletion fails, state is already cleared — session is effectively logged out
+    }
   }
 
   const value: AuthContextValue = {
     isAuthenticated: !!user,
-    isLoading,
+    isLoading: isLoading || !isHydrated,
     user,
     accessToken,
     refreshToken,
     studentRegister: handleStudentRegister,
     organizationRegister: handleOrganizationRegister,
+    handleLogin,
+    authenticatedFetch,
+    tryRefreshSession,
     logout,
   };
 

--- a/frontend/src/screens/auth/LoginScreen.test.tsx
+++ b/frontend/src/screens/auth/LoginScreen.test.tsx
@@ -1,8 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { jest } from '@jest/globals';
 
 import LoginScreen from './LoginScreen';
+
+// Need to import the real ApiError for instanceof checks in the component
+import { ApiError } from '../../services/api';
 
 // Mock de navegação
 const mockNavigate = jest.fn();
@@ -10,10 +13,29 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+// Mock AuthContext
+const mockHandleLogin = jest.fn();
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    handleLogin: mockHandleLogin,
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    studentRegister: jest.fn(),
+    organizationRegister: jest.fn(),
+    authenticatedFetch: jest.fn(),
+    logout: jest.fn(),
+  }),
+}));
+
 describe('LoginScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
+  // ─── Existing rendering tests (kept from before) ───
 
   it('renders the Liaison logo text', () => {
     render(<LoginScreen />);
@@ -79,5 +101,138 @@ describe('LoginScreen', () => {
   it('renders "ou" divider', () => {
     render(<LoginScreen />);
     expect(screen.getByText('ou')).toBeTruthy();
+  });
+
+  // ─── T1.10: Form submission tests ───
+
+  it('calls handleLogin with email and senha when Entrar is pressed', async () => {
+    mockHandleLogin.mockResolvedValueOnce(undefined);
+
+    render(<LoginScreen />);
+
+    // Fill in email and password
+    const emailInput = screen.getByTestId('input-email');
+    const senhaInput = screen.getByTestId('input-senha');
+
+    fireEvent.changeText(emailInput, 'maria@email.edu.br');
+    fireEvent.changeText(senhaInput, 'Senha123');
+
+    // Press Entrar
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(mockHandleLogin).toHaveBeenCalledWith('maria@email.edu.br', 'Senha123');
+    });
+  });
+
+  it('calls handleLogin even with empty fields (validation is server-side)', async () => {
+    mockHandleLogin.mockResolvedValueOnce(undefined);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(mockHandleLogin).toHaveBeenCalledWith('', '');
+    });
+  });
+
+  // ─── T1.11: Error handling tests ───
+
+  it('displays error message for invalid credentials (401)', async () => {
+    const apiError = new ApiError('Login failed', { detail: 'No active account' }, 401);
+    mockHandleLogin.mockRejectedValueOnce(apiError);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('E-mail ou senha inválidos')).toBeTruthy();
+    });
+  });
+
+  it('displays error message for network error', async () => {
+    const networkError = new TypeError('Network request failed');
+    mockHandleLogin.mockRejectedValueOnce(networkError);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro de conexão')).toBeTruthy();
+    });
+  });
+
+  it('displays generic error for unexpected failures', async () => {
+    mockHandleLogin.mockRejectedValueOnce(new Error('Something unexpected'));
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro ao realizar login. Tente novamente.')).toBeTruthy();
+    });
+  });
+
+  it('error message has the error banner testID', async () => {
+    const apiError = new ApiError('Login failed', { detail: 'No active account' }, 401);
+    mockHandleLogin.mockRejectedValueOnce(apiError);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-error')).toBeTruthy();
+    });
+  });
+
+  it('clears previous error message on new submission attempt', async () => {
+    // First attempt: fails
+    const apiError = new ApiError('Login failed', { detail: 'No active account' }, 401);
+    mockHandleLogin.mockRejectedValueOnce(apiError);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('E-mail ou senha inválidos')).toBeTruthy();
+    });
+
+    // Second attempt: succeeds (error should be cleared)
+    mockHandleLogin.mockResolvedValueOnce(undefined);
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    await waitFor(() => {
+      expect(() => screen.getByTestId('login-error')).toThrow();
+    });
+  });
+
+  // ─── T1.10: Loading state tests ───
+
+  it('shows loading state on button during submission', async () => {
+    // Make handleLogin never resolve so we can observe loading state
+    let resolveLogin: (value: void) => void;
+    const loginPromise = new Promise<void>((resolve) => {
+      resolveLogin = resolve;
+    });
+    mockHandleLogin.mockReturnValueOnce(loginPromise);
+
+    render(<LoginScreen />);
+
+    fireEvent.press(screen.getByTestId('button-entrar'));
+
+    // The button should show loading (the ActivityIndicator)
+    await waitFor(() => {
+      const button = screen.getByTestId('button-entrar');
+      expect(button.props.accessibilityState.disabled).toBe(true);
+    });
+
+    // Resolve to clean up
+    resolveLogin!();
   });
 });

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -11,16 +11,45 @@ import OrgTabIcon from '../../../assets/login_org_tab_icon.svg';
 
 import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
+import { useAuth } from '../../context/AuthContext';
+import { ApiError } from '../../services/api';
 import { colors } from '../../theme/colors';
 import { typography } from '../../theme/typography';
 
 export default function LoginScreen() {
   const navigation = useNavigation<any>();
+  const { handleLogin } = useAuth();
   const [email, setEmail] = useState('');
   const [senha, setSenha] = useState('');
   const [lembrar, setLembrar] = useState(false);
   const [activeTab, setActiveTab] = useState<'estudante' | 'organizacao'>('estudante');
   const [showPassword, setShowPassword] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleEntrar() {
+    setErrorMessage(null);
+    setIsSubmitting(true);
+    try {
+      await handleLogin(email, senha);
+      // On success, navigation happens automatically via RootNavigator
+      // (isAuthenticated becomes true → role-based stack renders)
+    } catch (e) {
+      if (e instanceof ApiError) {
+        if (e.status === 401) {
+          setErrorMessage('E-mail ou senha inválidos');
+        } else {
+          setErrorMessage('Erro de conexão');
+        }
+      } else if (e instanceof TypeError || (e as Error).message?.includes('Network')) {
+        setErrorMessage('Erro de conexão');
+      } else {
+        setErrorMessage('Erro ao realizar login. Tente novamente.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   return (
     <View style={styles.root}>
@@ -165,7 +194,19 @@ export default function LoginScreen() {
           </TouchableOpacity>
         </View>
 
-        <Button title="Entrar" onPress={() => {}} testID="button-entrar" />
+        {errorMessage && (
+          <View testID="login-error" style={styles.errorBanner}>
+            <Ionicons name="information-circle" size={16} color={colors.neutral.white} />
+            <Text style={styles.errorText}>{errorMessage}</Text>
+          </View>
+        )}
+
+        <Button
+          title="Entrar"
+          onPress={handleEntrar}
+          loading={isSubmitting}
+          testID="button-entrar"
+        />
 
         <View style={styles.dividerRow}>
           <View style={styles.dividerLine} />
@@ -326,4 +367,22 @@ const styles = StyleSheet.create({
 
   securityNotice: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 },
   securityText: { fontFamily: 'DMSans_400Regular', fontSize: 11, lineHeight: 17.6, color: colors.text.secondary },
+
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: '#d32f2f',
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    marginBottom: 20,
+  },
+  errorText: {
+    fontFamily: 'DMSans_500Medium',
+    fontSize: 13,
+    lineHeight: 20.8,
+    color: colors.neutral.white,
+  },
 });

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,4 +1,16 @@
-import { studentRegister, organizationRegister } from './api';
+import {
+  studentRegister,
+  organizationRegister,
+  login,
+  getStudentProfile,
+  updateStudentProfile,
+  uploadAvatar,
+  uploadBanner,
+  uploadGalleryPhotos,
+  deleteGalleryPhoto,
+  changePassword,
+  ApiError,
+} from './api';
 
 // Mock global fetch
 global.fetch = jest.fn();
@@ -237,5 +249,455 @@ describe('api.organizationRegister', () => {
     const body = JSON.parse(options.body);
     expect(body.email).toBe(ORG_PAYLOAD.email);
     expect(body.cnpj).toBe(ORG_PAYLOAD.cnpj);
+  });
+});
+
+const LOGIN_PAYLOAD = {
+  email: 'maria@email.edu.br',
+  password: 'Senha123',
+};
+
+const LOGIN_SUCCESS_RESPONSE = {
+  access: 'eyJaccess...',
+  refresh: 'eyJrefresh...',
+  role: 'estudante',
+  nome: 'Maria Silva',
+  id: 'uuid-maria',
+};
+
+describe('api.login', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('calls the correct endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    await login(LOGIN_PAYLOAD);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/auth/login/');
+  });
+
+  it('uses POST method', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    await login(LOGIN_PAYLOAD);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.method).toBe('POST');
+  });
+
+  it('sends JSON content-type header', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    await login(LOGIN_PAYLOAD);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers?.['Content-Type']).toBe('application/json');
+  });
+
+  it('serializes email and password in body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    await login(LOGIN_PAYLOAD);
+
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.email).toBe(LOGIN_PAYLOAD.email);
+    expect(body.password).toBe(LOGIN_PAYLOAD.password);
+  });
+
+  it('returns the response data on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    const result = await login(LOGIN_PAYLOAD);
+
+    expect(result).toEqual(LOGIN_SUCCESS_RESPONSE);
+  });
+
+  it('returns access, refresh, role, nome, id in response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => LOGIN_SUCCESS_RESPONSE,
+    });
+
+    const result = await login(LOGIN_PAYLOAD);
+
+    expect(result.access).toBe('eyJaccess...');
+    expect(result.refresh).toBe('eyJrefresh...');
+    expect(result.role).toBe('estudante');
+    expect(result.nome).toBe('Maria Silva');
+    expect(result.id).toBe('uuid-maria');
+  });
+
+  it('throws ApiError on 401 response (invalid credentials)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'No active account found with the given credentials' }),
+    });
+
+    await expect(login(LOGIN_PAYLOAD)).rejects.toThrow('Login failed');
+  });
+
+  it('includes status 401 in ApiError for invalid credentials', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'No active account found with the given credentials' }),
+    });
+
+    let caught: Error | null = null;
+    try {
+      await login(LOGIN_PAYLOAD);
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    expect((caught as any).status).toBe(401);
+  });
+
+  it('throws on network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network request failed'));
+
+    await expect(login(LOGIN_PAYLOAD)).rejects.toThrow('Network request failed');
+  });
+});
+
+// ── Profile API Tests ────────────────────────────────────────────
+
+const MOCK_TOKEN = 'eyJaccess-token...';
+const MOCK_PROFILE = {
+  id: 'uuid-profile',
+  email: 'maria@email.edu.br',
+  nome: 'Maria Silva',
+  universidade: 'UnB',
+  curso: 'Ciência da Computação',
+  matricula: '2024001234',
+  semestre_atual: 6,
+  turno: 'noturno',
+  ano_conclusao: 2027,
+  horas_extensao_exigidas: 200,
+  interesses: ['educacao', 'tecnologia'],
+  bio: 'Estudante apaixonada por tecnologia.',
+  avatar_url: 'http://localhost:8000/media/avatars/photo.jpg',
+  banner_url: 'http://localhost:8000/media/banners/banner.jpg',
+  gallery: [
+    { id: 'photo-1', image_url: 'http://localhost:8000/media/gallery/img1.jpg', created_at: '2026-06-08T00:00:00Z' },
+  ],
+  stats: {
+    total_hours_completed: 120,
+    total_hours_required: 200,
+    total_events: 8,
+  },
+  events: [
+    {
+      category: 'tecnologia',
+      title: 'Hackathon Solidário',
+      organization: 'Tech4Good',
+      date: '2026-05-20',
+      status: 'concluído',
+      hours: 20,
+    },
+  ],
+};
+
+describe('api.getStudentProfile', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('calls the correct endpoint with Bearer token', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_PROFILE,
+    });
+
+    await getStudentProfile(MOCK_TOKEN);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/');
+    expect(options?.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+  });
+
+  it('returns the profile data on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_PROFILE,
+    });
+
+    const result = await getStudentProfile(MOCK_TOKEN);
+    expect(result).toEqual(MOCK_PROFILE);
+    expect(result.nome).toBe('Maria Silva');
+    expect(result.stats.total_hours_completed).toBe(120);
+  });
+
+  it('throws ApiError on failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'Authentication credentials were not provided.' }),
+    });
+
+    await expect(getStudentProfile('invalid-token')).rejects.toThrow('Failed to fetch profile');
+  });
+});
+
+describe('api.updateStudentProfile', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('calls PATCH with JSON body and Bearer token', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_PROFILE,
+    });
+
+    const updateData = { nome: 'Maria Souza', bio: 'Nova bio' };
+    await updateStudentProfile(MOCK_TOKEN, updateData);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/update/');
+    expect(options.method).toBe('PATCH');
+    expect(options.headers?.['Content-Type']).toBe('application/json');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+    const body = JSON.parse(options.body);
+    expect(body.nome).toBe('Maria Souza');
+    expect(body.bio).toBe('Nova bio');
+  });
+
+  it('returns updated profile data', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ...MOCK_PROFILE, nome: 'Maria Souza' }),
+    });
+
+    const result = await updateStudentProfile(MOCK_TOKEN, { nome: 'Maria Souza' });
+    expect(result.nome).toBe('Maria Souza');
+  });
+
+  it('throws ApiError on validation failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ email: ['Este campo não pode ser alterado.'] }),
+    });
+
+    await expect(
+      updateStudentProfile(MOCK_TOKEN, { email: 'new@test.com' } as any),
+    ).rejects.toThrow('Failed to update profile');
+  });
+});
+
+describe('api.uploadAvatar', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('sends multipart form data with Bearer token (no Content-Type)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ avatar_url: 'http://localhost:8000/media/avatars/new.jpg' }),
+    });
+
+    const file = { uri: 'file:///photo.jpg', name: 'photo.jpg', type: 'image/jpeg' };
+    await uploadAvatar(MOCK_TOKEN, file);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/avatar/');
+    expect(options.method).toBe('POST');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+    // FormData should NOT have Content-Type set (let browser set boundary)
+    expect(options.headers?.['Content-Type']).toBeUndefined();
+    expect(options.body).toBeInstanceOf(FormData);
+  });
+
+  it('returns avatar_url on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ avatar_url: 'http://localhost:8000/media/avatars/new.jpg' }),
+    });
+
+    const file = { uri: 'file:///photo.jpg', name: 'photo.jpg', type: 'image/jpeg' };
+    const result = await uploadAvatar(MOCK_TOKEN, file);
+    expect(result.avatar_url).toBe('http://localhost:8000/media/avatars/new.jpg');
+  });
+});
+
+describe('api.uploadBanner', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('sends multipart form data with Bearer token', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ banner_url: 'http://localhost:8000/media/banners/new.jpg' }),
+    });
+
+    const file = { uri: 'file:///banner.jpg', name: 'banner.jpg', type: 'image/jpeg' };
+    await uploadBanner(MOCK_TOKEN, file);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/banner/');
+    expect(options.method).toBe('POST');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+    expect(options.body).toBeInstanceOf(FormData);
+  });
+});
+
+describe('api.uploadGalleryPhotos', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('sends multiple files as multipart form data', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => [
+        { id: 'p1', image_url: 'http://localhost:8000/media/gallery/p1.jpg', created_at: '2026-06-08T00:00:00Z' },
+        { id: 'p2', image_url: 'http://localhost:8000/media/gallery/p2.jpg', created_at: '2026-06-08T00:00:00Z' },
+      ],
+    });
+
+    const files = [
+      { uri: 'file:///g1.jpg', name: 'g1.jpg', type: 'image/jpeg' },
+      { uri: 'file:///g2.jpg', name: 'g2.jpg', type: 'image/jpeg' },
+    ];
+    await uploadGalleryPhotos(MOCK_TOKEN, files);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/gallery/');
+    expect(options.method).toBe('POST');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+    expect(options.body).toBeInstanceOf(FormData);
+  });
+
+  it('returns array of gallery photos on success', async () => {
+    const responseData = [
+      { id: 'p1', image_url: 'http://localhost:8000/media/gallery/p1.jpg', created_at: '2026-06-08T00:00:00Z' },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => responseData,
+    });
+
+    const files = [{ uri: 'file:///g1.jpg', name: 'g1.jpg', type: 'image/jpeg' }];
+    const result = await uploadGalleryPhotos(MOCK_TOKEN, files);
+    expect(result).toEqual(responseData);
+  });
+});
+
+describe('api.deleteGalleryPhoto', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('sends DELETE with Bearer token to correct photo URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => null,
+    });
+
+    await deleteGalleryPhoto(MOCK_TOKEN, 'photo-123');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/gallery/photo-123/');
+    expect(options.method).toBe('DELETE');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+  });
+
+  it('throws ApiError on failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: 'Foto não encontrada.' }),
+    });
+
+    await expect(deleteGalleryPhoto(MOCK_TOKEN, 'bad-id')).rejects.toThrow('Failed to delete gallery photo');
+  });
+});
+
+describe('api.changePassword', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('sends POST with new_password and confirm_password in JSON body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ detail: 'Senha alterada com sucesso.' }),
+    });
+
+    await changePassword(MOCK_TOKEN, 'NovaSenha123', 'NovaSenha123');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/students/me/change-password/');
+    expect(options.method).toBe('POST');
+    expect(options.headers?.['Content-Type']).toBe('application/json');
+    expect(options.headers?.Authorization).toBe(`Bearer ${MOCK_TOKEN}`);
+    const body = JSON.parse(options.body);
+    expect(body.new_password).toBe('NovaSenha123');
+    expect(body.confirm_password).toBe('NovaSenha123');
+  });
+
+  it('returns detail message on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ detail: 'Senha alterada com sucesso.' }),
+    });
+
+    const result = await changePassword(MOCK_TOKEN, 'NovaSenha123', 'NovaSenha123');
+    expect(result.detail).toBe('Senha alterada com sucesso.');
+  });
+
+  it('throws ApiError on password mismatch', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ confirm_password: ['As senhas não coincidem.'] }),
+    });
+
+    await expect(
+      changePassword(MOCK_TOKEN, 'Senha123', 'Different123'),
+    ).rejects.toThrow('Failed to change password');
   });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,54 @@
 import { apiUrl } from '../config/api';
 
+// ── Profile API Types ──────────────────────────────────────────────
+
+export interface GalleryPhoto {
+  id: string;
+  image_url: string;
+  created_at: string;
+}
+
+export interface StatsData {
+  total_hours_completed: number;
+  total_hours_required: number;
+  total_events: number;
+}
+
+export interface EventData {
+  category: string;
+  title: string;
+  organization: string;
+  date: string;
+  status: 'concluído' | 'em_andamento';
+  hours: number;
+}
+
+export interface ProfileData {
+  id: string;
+  email: string;
+  nome: string;
+  universidade: string;
+  curso: string;
+  matricula: string;
+  semestre_atual: number | null;
+  turno: string | null;
+  ano_conclusao: number | null;
+  horas_extensao_exigidas: number | null;
+  interesses: string[];
+  bio: string;
+  avatar_url: string | null;
+  banner_url: string | null;
+  gallery: GalleryPhoto[];
+  stats: StatsData;
+  events: EventData[];
+}
+
+export interface UploadFile {
+  uri: string;
+  name: string;
+  type: string;
+}
+
 export interface StudentRegisterPayload {
   email: string;
   password: string;
@@ -60,6 +109,19 @@ export type OrganizationRegisterResponse = {
     status: string;
   };
 };
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  access: string;
+  refresh: string;
+  role: string;
+  nome: string;
+  id: string;
+}
 
 export class ApiError extends Error {
   data: unknown;
@@ -207,4 +269,260 @@ export async function checkMatricula(
   }
 
   return data as { available: boolean };
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  const url = apiUrl('/auth/login/');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new ApiError('Login failed', data, response.status);
+  }
+
+  return data as LoginResponse;
+}
+
+/**
+ * Refresh expired access token using the stored refresh token.
+ * POST /auth/token/refresh/ — backend uses simplejwt with rotating tokens.
+ * Returns new { access, refresh } pair on success.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+): Promise<{ access: string; refresh: string }> {
+  const url = apiUrl('/auth/token/refresh/');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh: refreshToken }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new ApiError('Token refresh failed', data, response.status);
+  }
+
+  return data as { access: string; refresh: string };
+}
+
+/**
+ * Create authorization headers for an authenticated request.
+ * Use with fetch() to attach Bearer token.
+ *
+ * @example
+ *   fetch(url, { headers: authHeaders(token), body: ... })
+ */
+export function authHeaders(token: string): Record<string, string> {
+  return {
+    'Authorization': `Bearer ${token}`,
+  };
+}
+
+/**
+ * Perform an authenticated fetch request.
+ * Automatically attaches the Bearer token and JSON content-type.
+ * Useful as a convenience wrapper for protected API endpoints.
+ */
+export async function fetchWithAuth(
+  url: string,
+  token: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  return fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(token),
+      ...(options.headers as Record<string, string> | undefined),
+    },
+  });
+}
+
+// ── Profile API Functions ──────────────────────────────────────────
+
+/**
+ * Fetch the authenticated student's profile data.
+ * GET /students/me/
+ */
+export async function getStudentProfile(token: string): Promise<ProfileData> {
+  const url = apiUrl('/students/me/');
+  const response = await fetch(url, {
+    headers: { ...authHeaders(token) },
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to fetch profile', data, response.status);
+  }
+  return data as ProfileData;
+}
+
+/**
+ * Update the authenticated student's profile.
+ * PATCH /students/me/update/
+ */
+export async function updateStudentProfile(
+  token: string,
+  data: Partial<ProfileData>,
+): Promise<ProfileData> {
+  const url = apiUrl('/students/me/update/');
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(token),
+    },
+    body: JSON.stringify(data),
+  });
+  const responseData = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to update profile', responseData, response.status);
+  }
+  return responseData as ProfileData;
+}
+
+/**
+ * Upload a new avatar image for the student.
+ * POST /students/me/avatar/ (multipart/form-data)
+ */
+export async function uploadAvatar(
+  token: string,
+  file: UploadFile,
+): Promise<{ avatar_url: string }> {
+  const url = apiUrl('/students/me/avatar/');
+  const formData = new FormData();
+  formData.append('avatar', {
+    uri: file.uri,
+    name: file.name,
+    type: file.type,
+  } as any);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: formData,
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to upload avatar', data, response.status);
+  }
+  return data as { avatar_url: string };
+}
+
+/**
+ * Upload a new banner image for the student.
+ * POST /students/me/banner/ (multipart/form-data)
+ */
+export async function uploadBanner(
+  token: string,
+  file: UploadFile,
+): Promise<{ banner_url: string }> {
+  const url = apiUrl('/students/me/banner/');
+  const formData = new FormData();
+  formData.append('banner', {
+    uri: file.uri,
+    name: file.name,
+    type: file.type,
+  } as any);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: formData,
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to upload banner', data, response.status);
+  }
+  return data as { banner_url: string };
+}
+
+/**
+ * Upload multiple gallery photos.
+ * POST /students/me/gallery/ (multipart/form-data)
+ */
+export async function uploadGalleryPhotos(
+  token: string,
+  files: UploadFile[],
+): Promise<GalleryPhoto[]> {
+  const url = apiUrl('/students/me/gallery/');
+  const formData = new FormData();
+  files.forEach((file) => {
+    formData.append('images', {
+      uri: file.uri,
+      name: file.name,
+      type: file.type,
+    } as any);
+  });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: formData,
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to upload gallery photos', data, response.status);
+  }
+  return data as GalleryPhoto[];
+}
+
+/**
+ * Delete a gallery photo by ID.
+ * DELETE /students/me/gallery/{photoId}/
+ */
+export async function deleteGalleryPhoto(
+  token: string,
+  photoId: string,
+): Promise<void> {
+  const url = apiUrl(`/students/me/gallery/${photoId}/`);
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = null;
+    }
+    throw new ApiError('Failed to delete gallery photo', data, response.status);
+  }
+}
+
+/**
+ * Change the authenticated student's password.
+ * POST /students/me/change-password/
+ */
+export async function changePassword(
+  token: string,
+  newPassword: string,
+  confirmPassword: string,
+): Promise<{ detail: string }> {
+  const url = apiUrl('/students/me/change-password/');
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(token),
+    },
+    body: JSON.stringify({
+      new_password: newPassword,
+      confirm_password: confirmPassword,
+    }),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to change password', data, response.status);
+  }
+  return data as { detail: string };
 }


### PR DESCRIPTION
## Resumo

Implementa login funcional com persistência de sessão entre reloads do app. Resolve o pré-requisito crítico da US1.4.

## O que muda para o usuário

O estudante agora pode fazer login com e-mail e senha, e sua sessão permanece ativa mesmo após fechar e reabrir o app. Tokens são renovados automaticamente antes de expirar, e o logout limpa completamente a sessão.

## Testes
- 514 testes passando (205 backend + 309 frontend)
- Backend coverage: 96% (threshold: 80%) ✓
- Frontend coverage: 76.78% (threshold: 70%) ✓

## Segurança
- Tokens criptografados via Keychain iOS / Keystore Android
- Refresh token rotativo (simplejwt)

## Relacionado
- Refs #15 (US1.4)
- Bloqueia: feat/issue-15-student-profile
- Depende de: US1.3 (#58)