### PR TITLE
fix: atualiza Django 5.0 para 5.2 LTS (compatibilidade Python 3.14)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,9 @@
-django>=5.0,<5.1
+django>=5.2,<5.3
 djangorestframework>=3.15
 djangorestframework-simplejwt>=5.3
 django-cors-headers>=4.3
 psycopg2-binary>=2.9
 python-decouple>=3.8
-
 
 # Storage (S3)
 django-storages>=1.14


### PR DESCRIPTION
## Problema
O Django 5.0 não suporta Python 3.14 oficialmente, causando `AttributeError: 'super' object has no attribute 'dicts'` no admin.

## Solução
Atualização do Django 5.0 para 5.2 LTS, única versão com suporte oficial ao Python 3.14. Nenhum outro pacote foi alterado — todos os demais já são compatíveis com Django 5.2.

## Teste
- [x] `python manage.py check` passa sem erros
- [x] Admin acessível em `/admin/`

closes #49