### PR TITLE
feat(frontend): redesign org profile and edit screens to match Figma

### DIFF
--- a/frontend/src/screens/organization/OrgProfileEditScreen.tsx
+++ b/frontend/src/screens/organization/OrgProfileEditScreen.tsx
@@ -17,9 +17,8 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { useAuth } from '../../context/AuthContext';
 import GalleryGrid from '../../components/profile/GalleryGrid';
 import ImageViewer from '../../components/profile/ImageViewer';
-import PasswordChangeSection from '../../components/profile/PasswordChangeSection';
 import { colors } from '../../theme/colors';
-import { radius, shadows, spacing } from '../../theme/spacing';
+import { radius, spacing } from '../../theme/spacing';
 import { typography } from '../../theme/typography';
 import {
   getOrgProfile,
@@ -39,8 +38,14 @@ function isAuthError(e: unknown): e is { status: number } {
   return typeof e === 'object' && e !== null && 'status' in e && (e as any).status === 401;
 }
 
-const AREA_LABELS: Record<string, string> = {};
-INTERESSE_OPTIONS.forEach((opt) => { AREA_LABELS[opt.id] = opt.label; });
+const AREA_EMOJIS: Record<string, string> = {
+  saude: '🏥',
+  educacao: '📚',
+  tecnologia: '💻',
+  meio_ambiente: '🌿',
+  assistencia_social: '🤝',
+  arte_cultura: '🎨',
+};
 
 export default function OrgProfileEditScreen() {
   const navigation = useNavigation<any>();
@@ -53,19 +58,30 @@ export default function OrgProfileEditScreen() {
   const [successMessage, setSuccessMessage] = useState('');
 
   // Form fields
-  const [nomeFantasia, setNomeFantasia] = useState('');
   const [razaoSocial, setRazaoSocial] = useState('');
-  const [telefone, setTelefone] = useState('');
+  const [nomeFantasia, setNomeFantasia] = useState('');
   const [nomeResponsavel, setNomeResponsavel] = useState('');
-  const [mission, setMission] = useState('');
-  const [fullDescription, setFullDescription] = useState('');
+  const [email, setEmail] = useState('');
+  const [telefone, setTelefone] = useState('');
   const [site, setSite] = useState('');
   const [endereco, setEndereco] = useState('');
+  const [mission, setMission] = useState('');
+  const [fullDescription, setFullDescription] = useState('');
   const [areasDeAtuacao, setAreasDeAtuacao] = useState<string[]>([]);
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [bannerUrl, setBannerUrl] = useState<string | null>(null);
   const [gallery, setGallery] = useState<OrgGalleryPhoto[]>([]);
 
+  // Password fields
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+  const [passwordSuccess, setPasswordSuccess] = useState('');
+
+  // ImageViewer state
   const [viewerVisible, setViewerVisible] = useState(false);
   const [viewerUrl, setViewerUrl] = useState('');
   const [isUploadingImage, setIsUploadingImage] = useState(false);
@@ -75,14 +91,15 @@ export default function OrgProfileEditScreen() {
     try {
       const data = await getOrgProfile(accessToken);
       setProfile(data);
-      setNomeFantasia(data.nome_fantasia || '');
       setRazaoSocial(data.razao_social || '');
-      setTelefone(data.telefone || '');
+      setNomeFantasia(data.nome_fantasia || '');
       setNomeResponsavel(data.nome_responsavel || '');
-      setMission(data.mission || '');
-      setFullDescription(data.full_description || '');
+      setEmail(data.email || '');
+      setTelefone(data.telefone || '');
       setSite(data.site || '');
       setEndereco(data.endereco || '');
+      setMission(data.mission || '');
+      setFullDescription(data.full_description || '');
       setAreasDeAtuacao(data.areas_de_atuacao || []);
       setLogoUrl(data.logo_url);
       setBannerUrl(data.banner_url);
@@ -104,14 +121,18 @@ export default function OrgProfileEditScreen() {
     }
   }, [accessToken, tryRefreshSession]);
 
-  useEffect(() => { loadProfile(); }, [loadProfile]);
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
 
+  // ── Area Toggle ──
   function toggleArea(areaId: string) {
     setAreasDeAtuacao((prev) =>
       prev.includes(areaId) ? prev.filter((a) => a !== areaId) : [...prev, areaId]
     );
   }
 
+  // ── Save Handler ──
   async function handleSave() {
     if (!accessToken) return;
     setErrorMessage('');
@@ -119,10 +140,10 @@ export default function OrgProfileEditScreen() {
     setIsSaving(true);
     try {
       const payload: Partial<OrgProfileData> = {
-        nome_fantasia: nomeFantasia,
         razao_social: razaoSocial,
-        telefone,
+        nome_fantasia: nomeFantasia,
         nome_responsavel: nomeResponsavel,
+        telefone,
         mission,
         full_description: fullDescription,
         areas_de_atuacao: areasDeAtuacao,
@@ -133,21 +154,31 @@ export default function OrgProfileEditScreen() {
       setProfile(updated);
       setSuccessMessage('Perfil atualizado com sucesso!');
     } catch (e: any) {
-      setErrorMessage(e?.data?.detail || 'Erro ao salvar perfil.');
+      if (e.data && typeof e.data === 'object') {
+        const messages = Object.values(e.data).flat().join('\n');
+        setErrorMessage(messages || 'Erro ao salvar perfil. Tente novamente.');
+      } else {
+        setErrorMessage('Erro ao salvar perfil. Tente novamente.');
+      }
     } finally {
       setIsSaving(false);
     }
   }
 
+  // ── Image Picker Handlers ──
   async function pickAndUploadLogo() {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8,
+        mediaTypes: ['images'],
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 0.8,
       });
       if (result.canceled || !result.assets?.length) return;
       const asset = result.assets[0];
       const file: UploadFile = {
-        uri: asset.uri, name: asset.fileName || 'logo.jpg',
+        uri: asset.uri,
+        name: asset.fileName || 'logo.jpg',
         type: asset.mimeType || 'image/jpeg',
       };
       setIsUploadingImage(true);
@@ -164,12 +195,16 @@ export default function OrgProfileEditScreen() {
   async function pickAndUploadBanner() {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8,
+        mediaTypes: ['images'],
+        allowsEditing: true,
+        aspect: [16, 5],
+        quality: 0.8,
       });
       if (result.canceled || !result.assets?.length) return;
       const asset = result.assets[0];
       const file: UploadFile = {
-        uri: asset.uri, name: asset.fileName || 'banner.jpg',
+        uri: asset.uri,
+        name: asset.fileName || 'banner.jpg',
         type: asset.mimeType || 'image/jpeg',
       };
       setIsUploadingImage(true);
@@ -186,12 +221,14 @@ export default function OrgProfileEditScreen() {
   async function pickAndUploadGallery() {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8,
+        mediaTypes: ['images'],
         allowsMultipleSelection: true,
+        quality: 0.8,
       });
       if (result.canceled || !result.assets?.length) return;
       const files: UploadFile[] = result.assets.map((a) => ({
-        uri: a.uri, name: a.fileName || 'gallery.jpg',
+        uri: a.uri,
+        name: a.fileName || 'gallery.jpg',
         type: a.mimeType || 'image/jpeg',
       }));
       setIsUploadingImage(true);
@@ -205,11 +242,12 @@ export default function OrgProfileEditScreen() {
     }
   }
 
-  async function handleDeletePhoto(photoId: string) {
+  async function handleDeleteGalleryPhoto(photoId: string) {
     Alert.alert('Remover foto', 'Tem certeza que deseja remover esta foto?', [
       { text: 'Cancelar', style: 'cancel' },
       {
-        text: 'Remover', style: 'destructive',
+        text: 'Remover',
+        style: 'destructive',
         onPress: async () => {
           try {
             await deleteOrgGalleryPhoto(accessToken!, photoId);
@@ -222,6 +260,46 @@ export default function OrgProfileEditScreen() {
     ]);
   }
 
+  // ── Password Handler ──
+  async function handleChangePassword() {
+    setPasswordError('');
+    setPasswordSuccess('');
+    if (!newPassword) {
+      setPasswordError('A nova senha é obrigatória.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      setPasswordError('A senha deve ter no mínimo 8 caracteres.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError('As senhas não coincidem.');
+      return;
+    }
+    if (!accessToken) return;
+    setIsSavingPassword(true);
+    try {
+      const result = await changeOrgPassword(accessToken, newPassword, confirmPassword);
+      setPasswordSuccess(result.detail || 'Senha alterada com sucesso.');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (e: any) {
+      if (e.data && typeof e.data === 'object') {
+        const messages = Object.values(e.data).flat().join('\n');
+        setPasswordError(messages || 'Erro ao alterar a senha. Tente novamente.');
+      } else {
+        setPasswordError('Erro ao alterar a senha. Tente novamente.');
+      }
+    } finally {
+      setIsSavingPassword(false);
+    }
+  }
+
+  function getInitial(name: string): string {
+    return name ? name.charAt(0).toUpperCase() : '?';
+  }
+
+  // ── Loading State ──
   if (isLoading) {
     return (
       <View style={styles.loadingContainer}>
@@ -235,154 +313,472 @@ export default function OrgProfileEditScreen() {
 
   return (
     <View style={styles.root}>
-      {/* Header */}
+      {/* ═══ FIXED: Navy Header ═══ */}
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.headerBackButton}
           onPress={() => navigation.goBack()}
+          activeOpacity={0.7}
           testID="org-edit-back-button"
         >
-          <Ionicons name="arrow-back" size={20} color={colors.neutral.white} />
+          <Ionicons name="close" size={20} color={colors.neutral.white} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>Editar Perfil</Text>
+        <Text style={styles.headerTitle}>Editar Organização</Text>
         <TouchableOpacity
-          style={styles.saveButton}
+          testID="org-edit-save-button"
+          style={[styles.saveButton, isSaving && styles.saveButtonDisabled]}
           onPress={handleSave}
           disabled={isSaving}
-          testID="org-edit-save-button"
+          activeOpacity={0.7}
         >
-          <Text style={styles.saveButtonText}>{isSaving ? '...' : 'Salvar'}</Text>
+          {isSaving ? (
+            <ActivityIndicator size="small" color={colors.neutral.white} />
+          ) : (
+            <Text style={styles.saveButtonText}>Salvar</Text>
+          )}
         </TouchableOpacity>
       </View>
 
-      <KeyboardAwareScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        {/* Messages */}
+      {/* ═══ SCROLLABLE: Edit Content ═══ */}
+      <KeyboardAwareScrollView
+        style={styles.flex1}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        extraScrollHeight={90}
+        enableOnAndroid
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Success / Error Messages */}
+        {successMessage ? (
+          <View style={styles.successBanner} testID="org-edit-success-message">
+            <Text style={styles.successText}>{successMessage}</Text>
+          </View>
+        ) : null}
         {errorMessage ? (
-          <View style={styles.errorBanner}>
+          <View style={styles.errorBannerView} testID="org-edit-error-message">
             <Text style={styles.errorBannerText}>{errorMessage}</Text>
           </View>
         ) : null}
-        {successMessage ? (
-          <View style={styles.successBanner}>
-            <Text style={styles.successBannerText}>{successMessage}</Text>
-          </View>
-        ) : null}
 
-        {/* Logo Section */}
-        <View style={styles.imageSection}>
-          <TouchableOpacity onPress={pickAndUploadLogo} disabled={isUploadingImage}>
+        {/* ═══ Banner Section ═══ */}
+        <TouchableOpacity
+          testID="org-edit-banner-section"
+          style={styles.bannerContainer}
+          onPress={pickAndUploadBanner}
+          activeOpacity={0.8}
+          disabled={isUploadingImage}
+          accessibilityLabel="Alterar banner"
+        >
+          {bannerUrl ? (
+            <Image source={{ uri: bannerUrl }} style={styles.bannerImage} />
+          ) : (
+            <View style={[styles.bannerImage, styles.bannerPlaceholder]} />
+          )}
+          <View style={styles.bannerOverlay}>
+            <Ionicons name="camera" size={20} color={colors.neutral.white} />
+            <Text style={styles.bannerOverlayText}>Alterar banner</Text>
+          </View>
+
+          {/* Logo (overlapping banner bottom, left-aligned) */}
+          <TouchableOpacity
+            testID="org-edit-logo-section"
+            style={styles.logoOuter}
+            onPress={(e) => {
+              e.stopPropagation();
+              pickAndUploadLogo();
+            }}
+            activeOpacity={0.8}
+            disabled={isUploadingImage}
+            accessibilityLabel="Alterar logo"
+          >
             {logoUrl ? (
-              <Image source={{ uri: logoUrl }} style={styles.logoPreview} />
+              <Image source={{ uri: logoUrl }} style={styles.logoImage} />
             ) : (
               <View style={styles.logoPlaceholder}>
-                <Ionicons name="image-outline" size={32} color={colors.text.secondary} />
-                <Text style={styles.uploadHint}>Logo</Text>
+                <Text style={styles.logoInitial}>{getInitial(nomeFantasia || razaoSocial || '?')}</Text>
               </View>
             )}
+            <View style={styles.logoCameraOverlay}>
+              <Ionicons name="camera" size={14} color={colors.neutral.white} />
+            </View>
           </TouchableOpacity>
-          <Text style={styles.sectionLabel}>Logo da Organização</Text>
-        </View>
+        </TouchableOpacity>
 
-        {/* Banner Section */}
-        <View style={styles.imageSection}>
-          <TouchableOpacity onPress={pickAndUploadBanner} disabled={isUploadingImage}>
-            {bannerUrl ? (
-              <Image source={{ uri: bannerUrl }} style={styles.bannerPreview} />
-            ) : (
-              <View style={styles.bannerPlaceholder}>
-                <Ionicons name="image-outline" size={32} color={colors.text.secondary} />
-                <Text style={styles.uploadHint}>Banner</Text>
-              </View>
-            )}
-          </TouchableOpacity>
-          <Text style={styles.sectionLabel}>Banner</Text>
-        </View>
+        {/* Help text */}
+        <Text style={styles.helpText}>
+          Banner: 1200×400px recomendado · Logo: 512×512px · JPEG ou PNG · máx. 5MB
+        </Text>
 
-        {/* Form Fields */}
-        <View style={styles.formCard}>
-          <Text style={styles.fieldLabel}>Nome Fantasia</Text>
-          <TextInput style={styles.input} value={nomeFantasia} onChangeText={setNomeFantasia} placeholder="Nome fantasia" placeholderTextColor={colors.text.secondary} />
+        {/* ═══ Dados Cadastrais ═══ */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.iconSquare}>
+              <Ionicons name="business-outline" size={16} color={colors.brand.gold} />
+            </View>
+            <Text style={styles.sectionTitle}>Dados Cadastrais</Text>
+          </View>
 
-          <Text style={styles.fieldLabel}>Razão Social</Text>
-          <TextInput style={styles.input} value={razaoSocial} onChangeText={setRazaoSocial} placeholder="Razão social" placeholderTextColor={colors.text.secondary} />
+          {/* Info box */}
+          <View style={styles.infoBanner}>
+            <Ionicons name="eye-outline" size={16} color="#1d7a4a" style={styles.infoBannerIcon} />
+            <Text style={styles.infoBannerText}>
+              Os campos marcados com <Text style={styles.infoBannerBold}>👁 Público</Text> são exibidos aos estudantes nas páginas de vagas.
+            </Text>
+          </View>
 
-          <Text style={styles.fieldLabel}>CNPJ</Text>
-          <TextInput style={[styles.input, styles.inputReadonly]} value={profile.cnpj} editable={false} placeholderTextColor={colors.text.secondary} />
+          {/* Razão Social */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Razão Social</Text>
+              <Text style={styles.fieldRequired}>obrigatório</Text>
+            </View>
+            <TextInput
+              testID="org-edit-razao-social-input"
+              style={styles.input}
+              value={razaoSocial}
+              onChangeText={setRazaoSocial}
+              placeholder="Razão social"
+              placeholderTextColor={colors.text.secondary}
+            />
+          </View>
 
-          <Text style={styles.fieldLabel}>Telefone</Text>
-          <TextInput style={styles.input} value={telefone} onChangeText={setTelefone} placeholder="(XX) XXXXX-XXXX" placeholderTextColor={colors.text.secondary} keyboardType="phone-pad" />
+          {/* Nome Fantasia */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Nome Fantasia</Text>
+              <Text style={styles.fieldPublic}>👁 Público</Text>
+            </View>
+            <TextInput
+              testID="org-edit-nome-fantasia-input"
+              style={[styles.input, styles.inputActive]}
+              value={nomeFantasia}
+              onChangeText={setNomeFantasia}
+              placeholder="Nome fantasia"
+              placeholderTextColor={colors.text.secondary}
+            />
+          </View>
 
-          <Text style={styles.fieldLabel}>Nome do Responsável</Text>
-          <TextInput style={styles.input} value={nomeResponsavel} onChangeText={setNomeResponsavel} placeholder="Nome do responsável" placeholderTextColor={colors.text.secondary} />
+          {/* CNPJ (readonly) */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>CNPJ</Text>
+              <Text style={styles.fieldRequired}>obrigatório</Text>
+            </View>
+            <View style={[styles.input, styles.inputDisabled]}>
+              <Text style={styles.disabledText}>{profile.cnpj}</Text>
+            </View>
+            <Text style={styles.helperText}>
+              CNPJ não pode ser alterado. Entre em contato com o suporte se necessário.
+            </Text>
+          </View>
 
-          <Text style={styles.fieldLabel}>Missão</Text>
-          <TextInput style={[styles.input, styles.textArea]} value={mission} onChangeText={setMission} placeholder="Missão da organização (máx. 300 caracteres)" placeholderTextColor={colors.text.secondary} multiline maxLength={300} />
+          {/* Nome do Responsável */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Nome do Responsável</Text>
+              <Text style={styles.fieldRequired}>obrigatório</Text>
+            </View>
+            <TextInput
+              testID="org-edit-nome-responsavel-input"
+              style={styles.input}
+              value={nomeResponsavel}
+              onChangeText={setNomeResponsavel}
+              placeholder="Nome do responsável"
+              placeholderTextColor={colors.text.secondary}
+            />
+          </View>
 
-          <Text style={styles.fieldLabel}>Descrição Completa</Text>
-          <TextInput style={[styles.input, styles.textArea]} value={fullDescription} onChangeText={setFullDescription} placeholder="Descrição detalhada (máx. 2000 caracteres)" placeholderTextColor={colors.text.secondary} multiline maxLength={2000} />
+          {/* E-mail de contato */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>E-mail de contato</Text>
+              <Text style={styles.fieldPublic}>👁 Público</Text>
+            </View>
+            <TextInput
+              testID="org-edit-email-input"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+              placeholder="contato@organização.org"
+              placeholderTextColor={colors.text.secondary}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+          </View>
 
-          <Text style={styles.fieldLabel}>Site</Text>
-          <TextInput style={styles.input} value={site} onChangeText={setSite} placeholder="https://..." placeholderTextColor={colors.text.secondary} keyboardType="url" autoCapitalize="none" />
+          {/* Telefone */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Telefone</Text>
+              <Text style={styles.fieldPublic}>👁 Público</Text>
+            </View>
+            <TextInput
+              testID="org-edit-telefone-input"
+              style={styles.input}
+              value={telefone}
+              onChangeText={setTelefone}
+              placeholder="(XX) XXXXX-XXXX"
+              placeholderTextColor={colors.text.secondary}
+              keyboardType="phone-pad"
+            />
+          </View>
 
-          <Text style={styles.fieldLabel}>Endereço</Text>
-          <TextInput style={[styles.input, styles.textArea]} value={endereco} onChangeText={setEndereco} placeholder="Endereço completo" placeholderTextColor={colors.text.secondary} multiline maxLength={300} />
+          {/* Site */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Site</Text>
+              <Text style={styles.fieldOptional}>opcional</Text>
+            </View>
+            <TextInput
+              testID="org-edit-site-input"
+              style={styles.input}
+              value={site}
+              onChangeText={setSite}
+              placeholder="www.organizacao.org.br"
+              placeholderTextColor={colors.text.secondary}
+              keyboardType="url"
+              autoCapitalize="none"
+            />
+          </View>
 
-          {/* Áreas de Atuação */}
-          <Text style={styles.fieldLabel}>Áreas de Atuação</Text>
-          <View style={styles.areasRow}>
-            {INTERESSE_OPTIONS.map((opt) => (
-              <TouchableOpacity
-                key={opt.id}
-                style={[
-                  styles.areaChip,
-                  areasDeAtuacao.includes(opt.id) && styles.areaChipSelected,
-                ]}
-                onPress={() => toggleArea(opt.id)}
-                testID={`area-${opt.id}`}
-              >
-                <Text style={[
-                  styles.areaChipText,
-                  areasDeAtuacao.includes(opt.id) && styles.areaChipTextSelected,
-                ]}>
-                  {opt.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
+          {/* Endereço */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Endereço</Text>
+              <Text style={styles.fieldOptional}>opcional</Text>
+            </View>
+            <TextInput
+              testID="org-edit-endereco-input"
+              style={styles.input}
+              value={endereco}
+              onChangeText={setEndereco}
+              placeholder="Endereço completo"
+              placeholderTextColor={colors.text.secondary}
+            />
           </View>
         </View>
 
-        {/* Gallery */}
-        <View style={styles.formCard}>
-          <Text style={styles.sectionLabel}>Galeria</Text>
-          <TouchableOpacity
-            style={styles.addGalleryButton}
-            onPress={pickAndUploadGallery}
-            disabled={isUploadingImage}
-            testID="add-gallery-button"
-          >
-            <Ionicons name="add-circle-outline" size={24} color={colors.brand.navy} />
-            <Text style={styles.addGalleryText}>Adicionar Fotos</Text>
-          </TouchableOpacity>
-          {gallery.length > 0 && (
-            <GalleryGrid
-              photos={gallery.map((p) => ({ uri: p.image_url, id: p.id }))}
-              onPhotoPress={(uri) => { setViewerUrl(uri); setViewerVisible(true); }}
-              onDeletePhoto={handleDeletePhoto}
+        <View style={styles.sectionDivider} />
+
+        {/* ═══ Missão & Descrição ═══ */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.iconSquare}>
+              <Ionicons name="heart-outline" size={16} color={colors.brand.gold} />
+            </View>
+            <Text style={styles.sectionTitle}>Missão & Descrição</Text>
+          </View>
+
+          {/* Missão resumida */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Missão resumida</Text>
+              <Text style={styles.fieldPublic}>👁 Público</Text>
+            </View>
+            <TextInput
+              testID="org-edit-mission-input"
+              style={[styles.input, styles.textArea, styles.inputActive]}
+              value={mission}
+              onChangeText={(text) => {
+                if (text.length <= 200) setMission(text);
+              }}
+              placeholder="Descreva a missão da sua organização..."
+              placeholderTextColor={colors.text.secondary}
+              multiline
+              textAlignVertical="top"
             />
-          )}
+            <View style={styles.charCounterRow}>
+              <Text style={styles.helperText}>Aparece nos cards de vagas. Seja conciso e inspirador.</Text>
+              <Text style={styles.charCounter}>{mission.length} / 200</Text>
+            </View>
+          </View>
+
+          {/* Descrição completa */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Descrição completa</Text>
+              <Text style={styles.fieldOptional}>opcional</Text>
+            </View>
+            <TextInput
+              testID="org-edit-description-input"
+              style={[styles.input, styles.textArea]}
+              value={fullDescription}
+              onChangeText={(text) => {
+                if (text.length <= 1000) setFullDescription(text);
+              }}
+              placeholder="Descrição detalhada da organização..."
+              placeholderTextColor={colors.text.secondary}
+              multiline
+              textAlignVertical="top"
+            />
+            <Text style={styles.charCounter}>{fullDescription.length} / 1000</Text>
+          </View>
         </View>
 
-        {/* Change Password */}
-        <View style={styles.formCard}>
-          <PasswordChangeSection
-            onChangePassword={async (newPw, confirmPw) => {
-              await changeOrgPassword(accessToken!, newPw, confirmPw);
+        <View style={styles.sectionDivider} />
+
+        {/* ═══ Áreas de Atuação ═══ */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.iconSquare}>
+              <Ionicons name="grid-outline" size={16} color={colors.brand.gold} />
+            </View>
+            <Text style={styles.sectionTitle}>Áreas de Atuação</Text>
+          </View>
+          <View style={styles.chipsRow}>
+            {INTERESSE_OPTIONS.map((opt) => {
+              const isSelected = areasDeAtuacao.includes(opt.id);
+              const emoji = AREA_EMOJIS[opt.id] || '';
+              return (
+                <TouchableOpacity
+                  key={opt.id}
+                  testID={`area-chip-${opt.id}`}
+                  style={[
+                    styles.chip,
+                    isSelected && styles.chipSelected,
+                    !isSelected && styles.chipUnselected,
+                  ]}
+                  onPress={() => toggleArea(opt.id)}
+                  activeOpacity={0.7}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      isSelected && styles.chipTextSelected,
+                      !isSelected && styles.chipTextUnselected,
+                    ]}
+                  >
+                    {emoji} {opt.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+          <Text style={styles.helperText}>
+            Selecione todas as áreas que representam a missão da sua organização
+          </Text>
+        </View>
+
+        <View style={styles.sectionDivider} />
+
+        {/* ═══ Galeria de Fotos ═══ */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.iconSquare}>
+              <Ionicons name="images-outline" size={16} color={colors.brand.gold} />
+            </View>
+            <Text style={styles.sectionTitle}>Galeria de Fotos</Text>
+          </View>
+          <GalleryGrid
+            photos={gallery}
+            editable
+            onDelete={handleDeleteGalleryPhoto}
+            onAdd={pickAndUploadGallery}
+            onPhotoPress={(url) => {
+              setViewerUrl(url);
+              setViewerVisible(true);
             }}
           />
         </View>
+
+        <View style={styles.sectionDivider} />
+
+        {/* ═══ Segurança ═══ */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.iconSquare}>
+              <Ionicons name="lock-closed-outline" size={16} color={colors.brand.gold} />
+            </View>
+            <Text style={styles.sectionTitle}>Segurança</Text>
+          </View>
+
+          {/* Nova Senha */}
+          <View style={styles.fieldWrapper}>
+            <View style={styles.labelRow}>
+              <Text style={styles.label}>Nova senha</Text>
+              <Text style={styles.fieldOptional}>opcional</Text>
+            </View>
+            <View style={styles.passwordWrapper}>
+              <TextInput
+                testID="org-edit-new-password-input"
+                style={[styles.input, styles.passwordInput]}
+                value={newPassword}
+                onChangeText={setNewPassword}
+                secureTextEntry={!showNewPassword}
+                placeholder="Mínimo 8 caracteres"
+                placeholderTextColor={colors.text.secondary}
+              />
+              <TouchableOpacity
+                testID="org-edit-toggle-new-password"
+                style={styles.eyeButton}
+                onPress={() => setShowNewPassword(!showNewPassword)}
+                activeOpacity={0.7}
+              >
+                <Ionicons
+                  name={showNewPassword ? 'eye-off' : 'eye'}
+                  size={18}
+                  color={colors.text.secondary}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {/* Confirmar Senha */}
+          <View style={styles.fieldWrapper}>
+            <Text style={styles.label}>Confirmar nova senha</Text>
+            <View style={styles.passwordWrapper}>
+              <TextInput
+                testID="org-edit-confirm-password-input"
+                style={[styles.input, styles.passwordInput]}
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+                secureTextEntry={!showConfirmPassword}
+                placeholder="Repita a nova senha"
+                placeholderTextColor={colors.text.secondary}
+              />
+              <TouchableOpacity
+                testID="org-edit-toggle-confirm-password"
+                style={styles.eyeButton}
+                onPress={() => setShowConfirmPassword(!showConfirmPassword)}
+                activeOpacity={0.7}
+              >
+                <Ionicons
+                  name={showConfirmPassword ? 'eye-off' : 'eye'}
+                  size={18}
+                  color={colors.text.secondary}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {/* Password feedback */}
+          {passwordSuccess ? (
+            <Text style={styles.passwordSuccessText} testID="org-edit-password-success">{passwordSuccess}</Text>
+          ) : null}
+          {passwordError ? (
+            <Text style={styles.passwordErrorText} testID="org-edit-password-error">{passwordError}</Text>
+          ) : null}
+
+          {/* Change Password Button */}
+          <TouchableOpacity
+            testID="org-edit-change-password-button"
+            style={[styles.changePasswordButton, isSavingPassword && styles.changePasswordButtonDisabled]}
+            onPress={handleChangePassword}
+            disabled={isSavingPassword}
+            activeOpacity={0.8}
+          >
+            {isSavingPassword ? (
+              <ActivityIndicator color={colors.neutral.white} />
+            ) : (
+              <Text style={styles.changePasswordButtonText}>Alterar senha</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.bottomSpacer} />
       </KeyboardAwareScrollView>
 
-      {/* Image Viewer Modal */}
+      {/* ═══ Image Viewer Modal ═══ */}
       <ImageViewer
         visible={viewerVisible}
         imageUrl={viewerUrl}
@@ -393,72 +789,403 @@ export default function OrgProfileEditScreen() {
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: colors.neutral.bg },
-  loadingContainer: {
-    flex: 1, justifyContent: 'center', alignItems: 'center',
+  root: {
+    flex: 1,
     backgroundColor: colors.neutral.bg,
   },
-  loadingText: { ...typography.body, color: colors.text.secondary, marginTop: spacing.sm },
+  flex1: { flex: 1 },
+
+  // ── Loading ──
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    ...typography.body,
+    color: colors.text.secondary,
+    marginTop: 12,
+  },
+
+  // ── Header ──
   header: {
-    backgroundColor: colors.brand.navy, paddingTop: 50, paddingBottom: 16,
-    paddingHorizontal: 24, flexDirection: 'row', alignItems: 'center',
+    backgroundColor: colors.brand.navy,
+    flexDirection: 'row',
+    alignItems: 'center',
     justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 50,
+    paddingBottom: 14,
   },
-  headerBackButton: { padding: 4 },
-  headerTitle: { ...typography.h3, color: colors.neutral.white, flex: 1, textAlign: 'center' },
-  saveButton: { paddingHorizontal: 12, paddingVertical: 6 },
-  saveButtonText: { ...typography.button, color: colors.brand.gold },
-  scrollContent: { paddingBottom: 40 },
-  errorBanner: {
-    backgroundColor: '#d32f2f', marginHorizontal: 16, marginTop: 16,
-    padding: 12, borderRadius: radius.md,
+  headerBackButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  errorBannerText: { color: colors.neutral.white, ...typography.body },
+  headerTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 18,
+    color: colors.neutral.white,
+  },
+  saveButton: {
+    backgroundColor: colors.brand.gold,
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+    borderRadius: radius.round,
+    minWidth: 60,
+    alignItems: 'center',
+  },
+  saveButtonDisabled: {
+    opacity: 0.6,
+  },
+  saveButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 13,
+    color: colors.neutral.white,
+  },
+
+  // ── Success / Error Banners ──
   successBanner: {
-    backgroundColor: '#2e7d32', marginHorizontal: 16, marginTop: 16,
-    padding: 12, borderRadius: radius.md,
+    backgroundColor: '#e8f5e9',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    marginBottom: 2,
   },
-  successBannerText: { color: colors.neutral.white, ...typography.body },
-  imageSection: { alignItems: 'center', marginTop: 20 },
-  logoPreview: { width: 120, height: 120, borderRadius: 60, backgroundColor: '#eee' },
-  logoPlaceholder: {
-    width: 120, height: 120, borderRadius: 60, backgroundColor: '#eee',
-    justifyContent: 'center', alignItems: 'center',
+  successText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: '#1d7a4a',
   },
-  bannerPreview: { width: 320, height: 120, borderRadius: radius.md, backgroundColor: '#eee' },
+  errorBannerView: {
+    backgroundColor: '#fce4ec',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    marginBottom: 2,
+  },
+  errorBannerText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: '#ef4444',
+  },
+
+  // ── Scroll ──
+  scrollContent: {
+    paddingBottom: 60,
+  },
+
+  // ── Banner ──
+  bannerContainer: {
+    width: '100%',
+    height: 140,
+    position: 'relative',
+  },
+  bannerImage: {
+    width: '100%',
+    height: 140,
+  },
   bannerPlaceholder: {
-    width: 320, height: 120, borderRadius: radius.md, backgroundColor: '#eee',
-    justifyContent: 'center', alignItems: 'center',
+    backgroundColor: '#1a2744',
   },
-  uploadHint: { ...typography.caption, color: colors.text.secondary, marginTop: 4 },
-  sectionLabel: {
-    ...typography.subtitle, color: colors.text.primary, marginTop: 8, marginBottom: 4,
+  bannerOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
   },
-  formCard: {
-    marginHorizontal: 16, marginTop: 16, backgroundColor: colors.neutral.white,
-    borderRadius: radius.lg, padding: 20, ...shadows.sm,
+  bannerOverlayText: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.neutral.white,
   },
-  fieldLabel: {
-    ...typography.caption, color: colors.text.primary, marginTop: 16, marginBottom: 6,
+
+  // ── Logo ──
+  logoOuter: {
+    position: 'absolute',
+    left: 16,
+    bottom: -30,
+    width: 80,
+    height: 80,
+    borderRadius: 10,
+    borderWidth: 3,
+    borderColor: colors.neutral.white,
+    overflow: 'hidden',
   },
+  logoImage: {
+    width: '100%',
+    height: '100%',
+  },
+  logoPlaceholder: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colors.brand.navy,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logoInitial: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 22,
+    color: colors.neutral.white,
+  },
+  logoCameraOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 28,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // ── Help Text ──
+  helpText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+    marginTop: 44,
+    marginBottom: 4,
+    marginHorizontal: 20,
+    textAlign: 'center',
+  },
+
+  // ── Sections ──
+  section: {
+    marginHorizontal: 20,
+    marginTop: 24,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingBottom: 13,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.border,
+    marginBottom: 20,
+  },
+  iconSquare: {
+    width: 32,
+    height: 32,
+    borderRadius: 6,
+    backgroundColor: colors.accent.lightBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 10,
+  },
+  sectionTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 15,
+    color: colors.text.primary,
+  },
+  sectionDivider: {
+    height: 1,
+    backgroundColor: colors.neutral.border,
+    marginHorizontal: 20,
+    marginVertical: 24,
+  },
+
+  // ── Info Banner ──
+  infoBanner: {
+    backgroundColor: 'rgba(29,122,74,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(29,122,74,0.2)',
+    borderRadius: 6,
+    padding: 12,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 20,
+  },
+  infoBannerIcon: {
+    marginRight: 8,
+    marginTop: 1,
+  },
+  infoBannerText: {
+    flex: 1,
+    fontFamily: typography.body.fontFamily,
+    fontSize: 12,
+    color: '#1d7a4a',
+    lineHeight: 18,
+  },
+  infoBannerBold: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 12,
+  },
+
+  // ── Field Wrapper ──
+  fieldWrapper: {
+    marginBottom: spacing.formGap,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.labelGap,
+  },
+  label: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.text.info,
+  },
+  fieldRequired: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 11,
+    color: colors.brand.gold,
+  },
+  fieldPublic: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 11,
+    color: '#1d7a4a',
+  },
+  fieldOptional: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+  },
+
+  // ── Input ──
   input: {
-    borderWidth: 1, borderColor: colors.neutral.border, borderRadius: radius.md,
-    paddingHorizontal: 12, paddingVertical: 10, ...typography.body, color: colors.text.primary,
+    height: 52,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: colors.neutral.border,
+    paddingHorizontal: 16,
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    color: colors.text.primary,
     backgroundColor: colors.neutral.white,
   },
-  inputReadonly: { backgroundColor: '#f5f5f5', color: colors.text.secondary },
-  textArea: { minHeight: 80, textAlignVertical: 'top' },
-  areasRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  areaChip: {
-    paddingHorizontal: 14, paddingVertical: 8, borderRadius: radius.full,
-    backgroundColor: '#f0f0f0', borderWidth: 1, borderColor: 'transparent',
+  inputActive: {
+    borderColor: colors.brand.gold,
+    shadowColor: colors.brand.gold,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.12,
+    shadowRadius: 3,
+    elevation: 2,
   },
-  areaChipSelected: { backgroundColor: colors.brand.navy, borderColor: colors.brand.navy },
-  areaChipText: { ...typography.caption, color: colors.text.secondary },
-  areaChipTextSelected: { color: colors.neutral.white },
-  addGalleryButton: {
-    flexDirection: 'row', alignItems: 'center', gap: 8,
-    paddingVertical: 12, justifyContent: 'center',
+  inputDisabled: {
+    backgroundColor: '#f5f3ef',
+    justifyContent: 'center',
+    height: 52,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: colors.neutral.border,
+    paddingHorizontal: 16,
   },
-  addGalleryText: { ...typography.button, color: colors.brand.navy },
+  disabledText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    color: colors.text.secondary,
+  },
+  textArea: {
+    height: 120,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  helperText: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+    marginTop: 4,
+  },
+  charCounterRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  charCounter: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+    textAlign: 'right',
+    marginTop: 4,
+  },
+
+  // ── Chips ──
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
+  chip: {
+    borderRadius: radius.round,
+    paddingHorizontal: 15,
+    paddingVertical: 9,
+    borderWidth: 1,
+  },
+  chipSelected: {
+    backgroundColor: colors.accent.lightBg,
+    borderColor: colors.brand.gold,
+  },
+  chipUnselected: {
+    backgroundColor: colors.neutral.white,
+    borderColor: colors.neutral.border,
+  },
+  chipText: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+  },
+  chipTextSelected: {
+    color: colors.brand.gold,
+  },
+  chipTextUnselected: {
+    color: colors.text.secondary,
+  },
+
+  // ── Password ──
+  passwordWrapper: {
+    position: 'relative',
+  },
+  passwordInput: {
+    paddingRight: 44,
+  },
+  eyeButton: {
+    position: 'absolute',
+    right: 12,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+  },
+  passwordSuccessText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: '#1d7a4a',
+    marginTop: 8,
+  },
+  passwordErrorText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: '#ef4444',
+    marginTop: 8,
+  },
+  changePasswordButton: {
+    marginTop: 16,
+    height: 52,
+    borderRadius: radius.sm,
+    backgroundColor: colors.brand.gold,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  changePasswordButtonDisabled: {
+    opacity: 0.6,
+  },
+  changePasswordButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 15,
+    color: colors.neutral.white,
+  },
+
+  // ── Bottom Spacer ──
+  bottomSpacer: {
+    height: 32,
+  },
 });

--- a/frontend/src/screens/organization/OrgProfileScreen.tsx
+++ b/frontend/src/screens/organization/OrgProfileScreen.tsx
@@ -16,20 +16,21 @@ import { useAuth } from '../../context/AuthContext';
 import GalleryPreview from '../../components/profile/GalleryPreview';
 import ImageViewer from '../../components/profile/ImageViewer';
 import { colors } from '../../theme/colors';
-import { radius, shadows, spacing } from '../../theme/spacing';
+import { radius, shadows } from '../../theme/spacing';
 import { typography } from '../../theme/typography';
-import {
-  getOrgProfile,
-  OrgProfileData,
-} from '../../services/api';
+import { getOrgProfile, OrgProfileData } from '../../services/api';
+import { INTERESSE_OPTIONS } from '../../constants/interests';
 
 function isAuthError(e: unknown): e is { status: number } {
   return typeof e === 'object' && e !== null && 'status' in e && (e as any).status === 401;
 }
 
+const AREA_LABELS: Record<string, string> = {};
+INTERESSE_OPTIONS.forEach((opt) => { AREA_LABELS[opt.id] = opt.label; });
+
 export default function OrgProfileScreen() {
   const navigation = useNavigation<any>();
-  const { accessToken, tryRefreshSession, logout } = useAuth();
+  const { accessToken, tryRefreshSession } = useAuth();
 
   const [profile, setProfile] = useState<OrgProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -93,7 +94,7 @@ export default function OrgProfileScreen() {
     return (
       <View style={styles.loadingContainer}>
         <Ionicons name="information-circle" size={48} color={colors.text.secondary} />
-        <Text style={styles.errorText}>{errorMessage}</Text>
+        <Text style={styles.errorBanner}>{errorMessage}</Text>
         <TouchableOpacity style={styles.retryButton} onPress={loadProfile}>
           <Text style={styles.retryButtonText}>Tentar novamente</Text>
         </TouchableOpacity>
@@ -102,6 +103,9 @@ export default function OrgProfileScreen() {
   }
 
   if (!profile) return null;
+
+  const displayName = profile.nome_fantasia || profile.razao_social;
+  const openPositionsCount = (profile.open_positions as any[])?.length ?? 0;
 
   return (
     <View style={styles.root}>
@@ -115,7 +119,7 @@ export default function OrgProfileScreen() {
         >
           <Ionicons name="arrow-back" size={20} color={colors.neutral.white} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>Perfil Institucional</Text>
+        <Text style={styles.headerTitle}>Perfil da Organização</Text>
         <TouchableOpacity
           testID="org-profile-edit-button"
           style={styles.editButton}
@@ -131,9 +135,7 @@ export default function OrgProfileScreen() {
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
-        }
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
       >
         {/* Banner */}
         <TouchableOpacity
@@ -155,42 +157,71 @@ export default function OrgProfileScreen() {
           )}
         </TouchableOpacity>
 
-        {/* Logo (overlapping banner) */}
-        <View style={styles.logoWrapper}>
-          <TouchableOpacity
-            style={styles.logoOuter}
-            onPress={() => {
-              if (profile.logo_url) {
-                setViewerUrl(profile.logo_url);
-                setViewerVisible(true);
-              }
-            }}
-            activeOpacity={profile.logo_url ? 0.8 : 1}
-            disabled={!profile.logo_url}
-            accessibilityLabel="Ver logo"
-          >
-            {profile.logo_url ? (
-              <Image source={{ uri: profile.logo_url }} style={styles.logoImage} />
-            ) : (
-              <View style={styles.logoPlaceholder}>
-                <Text style={styles.logoInitial}>{getInitial(profile.nome_fantasia || profile.razao_social)}</Text>
-              </View>
-            )}
-          </TouchableOpacity>
-        </View>
+        {/* ═══ Profile Info Block (white, full-width) ═══ */}
+        <View style={styles.profileBlock}>
+          {/* Logo (overlapping banner, left-aligned) */}
+          <View style={styles.logoRow}>
+            <TouchableOpacity
+              style={styles.logoOuter}
+              onPress={() => {
+                if (profile.logo_url) {
+                  setViewerUrl(profile.logo_url);
+                  setViewerVisible(true);
+                }
+              }}
+              activeOpacity={profile.logo_url ? 0.8 : 1}
+              disabled={!profile.logo_url}
+              accessibilityLabel="Ver logo"
+            >
+              {profile.logo_url ? (
+                <Image source={{ uri: profile.logo_url }} style={styles.logoImage} />
+              ) : (
+                <View style={styles.logoPlaceholder}>
+                  <Text style={styles.logoInitial}>{getInitial(displayName)}</Text>
+                </View>
+              )}
+            </TouchableOpacity>
 
-        {/* ═══ White Card: Profile Info ═══ */}
-        <View style={styles.card}>
+            {/* Share button */}
+            <TouchableOpacity style={styles.iconButton} activeOpacity={0.7}>
+              <Ionicons name="share-outline" size={16} color={colors.text.primary} />
+            </TouchableOpacity>
+          </View>
+
           {/* Name */}
-          <Text style={styles.orgName}>{profile.nome_fantasia || profile.razao_social}</Text>
-          {profile.nome_fantasia && (
-            <Text style={styles.razaoSocial}>{profile.razao_social}</Text>
-          )}
+          <Text style={styles.orgName}>{displayName}</Text>
 
-          {/* Badge */}
-          <View style={styles.badge}>
-            <Text style={styles.badgeEmoji}>🏢</Text>
-            <Text style={styles.badgeText}>Organização</Text>
+          {/* Category / Razão Social subtitle */}
+          {profile.nome_fantasia && profile.razao_social ? (
+            <Text style={styles.orgCategory}>{profile.razao_social}</Text>
+          ) : null}
+
+          {/* Badges: Verified + Location */}
+          <View style={styles.badgesRow}>
+            <View style={styles.verifiedBadge}>
+              <Text style={styles.verifiedText}>✓ Verificada</Text>
+            </View>
+            {profile.endereco ? (
+              <View style={styles.locationBadge}>
+                <Text style={styles.locationText}>📍 {profile.endereco}</Text>
+              </View>
+            ) : null}
+          </View>
+
+          {/* CTA Row */}
+          <View style={styles.ctaRow}>
+            <TouchableOpacity
+              style={styles.primaryButton}
+              activeOpacity={0.8}
+              testID="org-view-positions-button"
+            >
+              <Text style={styles.primaryButtonText}>
+                {'Ver Vagas Abertas' + (openPositionsCount > 0 ? ` (${openPositionsCount})` : '')}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.bookmarkButton} activeOpacity={0.7}>
+              <Ionicons name="bookmark-outline" size={20} color={colors.text.primary} />
+            </TouchableOpacity>
           </View>
 
           {/* Stats */}
@@ -210,81 +241,134 @@ export default function OrgProfileScreen() {
               <Text style={styles.statLabel}>Avaliação</Text>
             </View>
           </View>
+        </View>
 
-          {/* Mission */}
-          {profile.mission ? (
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Missão</Text>
-              <Text style={styles.sectionText}>{profile.mission}</Text>
-            </View>
-          ) : null}
-
-          {/* Áreas de Atuação */}
-          {profile.areas_de_atuacao && profile.areas_de_atuacao.length > 0 && (
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Áreas de Atuação</Text>
-              <View style={styles.tagsRow}>
-                {profile.areas_de_atuacao.map((area) => (
-                  <View key={area} style={styles.tag}>
-                    <Text style={styles.tagText}>{area}</Text>
-                  </View>
-                ))}
-              </View>
-            </View>
-          )}
-
-          {/* Contact Info */}
+        {/* ═══ Missão ═══ */}
+        {(profile.mission || profile.full_description) ? (
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Contato</Text>
-            {profile.telefone ? (
-              <View style={styles.contactRow}>
-                <Ionicons name="call-outline" size={16} color={colors.text.secondary} />
-                <Text style={styles.contactText}>{profile.telefone}</Text>
+            <Text style={styles.sectionTitle}>Missão</Text>
+            {profile.mission ? (
+              <View style={styles.missionBox}>
+                <Text style={styles.missionBoxLabel}>NOSSA MISSÃO</Text>
+                <Text style={styles.missionBoxText}>{`"${profile.mission}"`}</Text>
               </View>
             ) : null}
-            {profile.email ? (
-              <View style={styles.contactRow}>
-                <Ionicons name="mail-outline" size={16} color={colors.text.secondary} />
-                <Text style={styles.contactText}>{profile.email}</Text>
+            {profile.full_description ? (
+              <Text style={styles.descriptionText}>{profile.full_description}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* ═══ Áreas de Atuação ═══ */}
+        {profile.areas_de_atuacao && profile.areas_de_atuacao.length > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Áreas de Atuação</Text>
+            <View style={styles.chipsRow}>
+              {profile.areas_de_atuacao.map((area) => (
+                <View key={area} style={styles.chip}>
+                  <Text style={styles.chipText}>
+                    {AREA_LABELS[area] || area.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {/* ═══ Dados Institucionais ═══ */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Dados Institucionais</Text>
+          <View style={styles.infoRows}>
+            {profile.razao_social ? (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Razão Social</Text>
+                <Text style={styles.infoValue} numberOfLines={1}>{profile.razao_social}</Text>
               </View>
             ) : null}
-            {profile.site ? (
-              <View style={styles.contactRow}>
-                <Ionicons name="globe-outline" size={16} color={colors.text.secondary} />
-                <Text style={styles.contactText}>{profile.site}</Text>
+            {profile.nome_responsavel ? (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Responsável</Text>
+                <Text style={styles.infoValue}>{profile.nome_responsavel}</Text>
               </View>
             ) : null}
             {profile.endereco ? (
-              <View style={styles.contactRow}>
-                <Ionicons name="location-outline" size={16} color={colors.text.secondary} />
-                <Text style={styles.contactText}>{profile.endereco}</Text>
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Localização</Text>
+                <Text style={styles.infoValue}>{profile.endereco}</Text>
               </View>
             ) : null}
-          </View>
-
-          {/* Gallery */}
-          {profile.gallery && profile.gallery.length > 0 && (
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Galeria</Text>
-              <GalleryPreview
-                photos={profile.gallery.map((p) => ({ uri: p.image_url, id: p.id }))}
-                onPhotoPress={(uri) => {
-                  setViewerUrl(uri);
-                  setViewerVisible(true);
-                }}
-              />
+            <View style={[styles.infoRow, styles.infoRowLast]}>
+              <Text style={styles.infoLabel}>Status</Text>
+              <Text style={[styles.infoValue, styles.infoValueGreen]}>✓ Aprovada pela Liaison</Text>
             </View>
-          )}
-
-          {/* CNPJ (read-only info) */}
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>CNPJ</Text>
-            <Text style={styles.sectionText}>{profile.cnpj}</Text>
           </View>
         </View>
+
+        {/* ═══ Contato ═══ */}
+        {(profile.email || profile.telefone || profile.site) ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Contato</Text>
+            <View style={styles.contactCards}>
+              {profile.email ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.navy }]}>
+                    <Ionicons name="mail-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>E-MAIL</Text>
+                    <Text style={styles.contactCardValue}>{profile.email}</Text>
+                  </View>
+                </View>
+              ) : null}
+              {profile.telefone ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.navy }]}>
+                    <Ionicons name="call-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>TELEFONE</Text>
+                    <Text style={styles.contactCardValue}>{profile.telefone}</Text>
+                  </View>
+                </View>
+              ) : null}
+              {profile.site ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.gold }]}>
+                    <Ionicons name="globe-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>SITE</Text>
+                    <Text style={[styles.contactCardValue, styles.contactCardLink]}>{profile.site}</Text>
+                  </View>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+
+        {/* ═══ Galeria ═══ */}
+        {profile.gallery && profile.gallery.length > 0 ? (
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <Text style={styles.sectionTitle}>Álbum de Eventos</Text>
+              <Text style={styles.sectionSubtext}>{profile.gallery.length} fotos</Text>
+            </View>
+            <GalleryPreview
+              photos={profile.gallery}
+              onPhotoPress={(photo) => {
+                if (photo.image_url) {
+                  setViewerUrl(photo.image_url);
+                  setViewerVisible(true);
+                }
+              }}
+            />
+          </View>
+        ) : null}
+
+        <View style={styles.bottomSpacer} />
       </ScrollView>
 
-      {/* Image Viewer Modal */}
+      {/* ═══ Image Viewer Modal ═══ */}
       <ImageViewer
         visible={viewerVisible}
         imageUrl={viewerUrl}
@@ -295,86 +379,408 @@ export default function OrgProfileScreen() {
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: colors.neutral.bg },
+  root: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+  },
+
+  // ── Loading / Error ──
   loadingContainer: {
-    flex: 1, justifyContent: 'center', alignItems: 'center',
-    backgroundColor: colors.neutral.bg, padding: spacing.lg,
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
   },
   loadingText: {
-    ...typography.body, color: colors.text.secondary, marginTop: spacing.sm,
+    ...typography.body,
+    color: colors.text.secondary,
+    marginTop: 12,
   },
-  errorText: {
-    ...typography.body, color: colors.text.secondary,
-    textAlign: 'center', marginTop: spacing.md,
+  errorBanner: {
+    ...typography.body,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: 16,
+    marginBottom: 20,
   },
   retryButton: {
-    marginTop: spacing.lg, paddingHorizontal: spacing.xl, paddingVertical: spacing.sm,
-    backgroundColor: colors.brand.navy, borderRadius: radius.md,
+    backgroundColor: colors.brand.gold,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: radius.sm,
   },
-  retryButtonText: { ...typography.button, color: colors.neutral.white },
+  retryButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 15,
+    color: colors.neutral.white,
+  },
+
+  // ── Header ──
   header: {
-    backgroundColor: colors.brand.navy, paddingTop: 50, paddingBottom: 16,
-    paddingHorizontal: 24, flexDirection: 'row', alignItems: 'center',
+    backgroundColor: colors.brand.navy,
+    flexDirection: 'row',
+    alignItems: 'center',
     justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 50,
+    paddingBottom: 14,
   },
-  headerBackButton: { padding: 4 },
+  headerBackButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   headerTitle: {
-    ...typography.h3, color: colors.neutral.white, flex: 1, textAlign: 'center',
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 18,
+    color: colors.neutral.white,
   },
-  editButton: { paddingHorizontal: 12, paddingVertical: 6 },
-  editButtonText: { ...typography.button, color: colors.brand.gold },
-  scrollView: { flex: 1 },
-  scrollContent: { paddingBottom: spacing.xl },
-  bannerContainer: { height: 180 },
-  bannerImage: { width: '100%', height: '100%' },
-  bannerPlaceholder: { backgroundColor: '#e0d5c8' },
-  logoWrapper: { alignItems: 'center', marginTop: -60 },
+  editButton: {
+    backgroundColor: colors.brand.gold,
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+    borderRadius: radius.round,
+  },
+  editButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 13,
+    color: colors.neutral.white,
+  },
+
+  // ── Scroll ──
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 40,
+  },
+
+  // ── Banner ──
+  bannerContainer: {
+    width: '100%',
+    height: 180,
+  },
+  bannerImage: {
+    width: '100%',
+    height: 180,
+  },
+  bannerPlaceholder: {
+    backgroundColor: '#1a2744',
+  },
+
+  // ── Profile Block ──
+  profileBlock: {
+    backgroundColor: colors.neutral.white,
+    paddingHorizontal: 16,
+    paddingBottom: 20,
+  },
+  logoRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    marginTop: -44,
+    marginBottom: 8,
+  },
   logoOuter: {
-    width: 120, height: 120, borderRadius: 60, borderWidth: 4,
-    borderColor: colors.neutral.white, overflow: 'hidden',
-    backgroundColor: colors.neutral.white, ...shadows.sm,
+    width: 88,
+    height: 88,
+    borderRadius: 16,
+    borderWidth: 4,
+    borderColor: colors.neutral.white,
+    overflow: 'hidden',
+    ...shadows.card,
   },
-  logoImage: { width: '100%', height: '100%' },
+  logoImage: {
+    width: '100%',
+    height: '100%',
+  },
   logoPlaceholder: {
-    width: '100%', height: '100%', backgroundColor: colors.brand.gold,
-    justifyContent: 'center', alignItems: 'center',
+    width: '100%',
+    height: '100%',
+    backgroundColor: colors.brand.navy,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  logoInitial: { ...typography.h2, color: colors.neutral.white },
-  card: {
-    marginHorizontal: 16, marginTop: 20, backgroundColor: colors.neutral.white,
-    borderRadius: radius.lg, padding: 20, ...shadows.sm,
+  logoInitial: {
+    fontFamily: typography.h1.fontFamily,
+    fontSize: 28,
+    color: colors.neutral.white,
+    letterSpacing: 1,
   },
-  orgName: { ...typography.h2, color: colors.text.primary, textAlign: 'center' },
-  razaoSocial: {
-    ...typography.body, color: colors.text.secondary, textAlign: 'center', marginTop: 4,
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 52,
   },
-  badge: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
-    marginTop: 12, gap: 6,
+
+  // ── Name / Category ──
+  orgName: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 21,
+    color: colors.text.primary,
+    marginBottom: 4,
   },
-  badgeEmoji: { fontSize: 16 },
-  badgeText: { ...typography.caption, color: colors.text.secondary },
+  orgCategory: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginBottom: 12,
+  },
+
+  // ── Badges ──
+  badgesRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 16,
+    flexWrap: 'wrap',
+  },
+  verifiedBadge: {
+    backgroundColor: 'rgba(29,122,74,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(29,122,74,0.2)',
+    borderRadius: radius.round,
+    paddingHorizontal: 13,
+    paddingVertical: 5,
+  },
+  verifiedText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: '#1d7a4a',
+  },
+  locationBadge: {
+    backgroundColor: 'rgba(26,39,68,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(26,39,68,0.15)',
+    borderRadius: radius.round,
+    paddingHorizontal: 13,
+    paddingVertical: 5,
+  },
+  locationText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.brand.navy,
+  },
+
+  // ── CTA Row ──
+  ctaRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 16,
+  },
+  primaryButton: {
+    flex: 1,
+    height: 48,
+    backgroundColor: colors.brand.navy,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 14,
+    color: colors.neutral.white,
+  },
+  bookmarkButton: {
+    width: 48,
+    height: 48,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // ── Stats ──
   statsRow: {
-    flexDirection: 'row', marginTop: 20, paddingVertical: 16,
-    borderTopWidth: 1, borderBottomWidth: 1, borderColor: '#f0f0f0',
+    flexDirection: 'row',
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.neutral.border,
   },
-  statItem: { flex: 1, alignItems: 'center' },
-  statNumber: { ...typography.h3, color: colors.brand.navy },
-  statLabel: { ...typography.caption, color: colors.text.secondary, marginTop: 4 },
-  statDivider: { width: 1, backgroundColor: '#f0f0f0' },
-  section: { marginTop: 20 },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statNumber: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 22,
+    color: colors.text.primary,
+  },
+  statLabel: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    backgroundColor: colors.neutral.border,
+  },
+
+  // ── Sections ──
+  section: {
+    marginTop: 2,
+    backgroundColor: colors.neutral.white,
+    padding: 16,
+  },
+  sectionHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
   sectionTitle: {
-    ...typography.subtitle, color: colors.text.primary, marginBottom: 8,
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 16,
+    color: colors.text.primary,
+    marginBottom: 12,
   },
-  sectionText: { ...typography.body, color: colors.text.secondary, lineHeight: 22 },
-  tagsRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  tag: {
-    backgroundColor: '#f0f0f0', paddingHorizontal: 12, paddingVertical: 6,
-    borderRadius: radius.full,
+  sectionSubtext: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+    marginBottom: 12,
   },
-  tagText: { ...typography.caption, color: colors.text.primary },
-  contactRow: {
-    flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 8,
+
+  // ── Mission ──
+  missionBox: {
+    backgroundColor: '#fdf5ec',
+    borderWidth: 1,
+    borderColor: 'rgba(212,129,58,0.2)',
+    borderRadius: 10,
+    padding: 17,
+    marginBottom: 16,
   },
-  contactText: { ...typography.body, color: colors.text.secondary },
+  missionBoxLabel: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.brand.gold,
+    letterSpacing: 0.6,
+    marginBottom: 8,
+  },
+  missionBoxText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: '#3a4560',
+    lineHeight: 22,
+  },
+  descriptionText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    color: '#3a4560',
+    lineHeight: 23,
+  },
+
+  // ── Chips ──
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    backgroundColor: colors.accent.lightBg,
+    borderWidth: 1,
+    borderColor: colors.brand.gold,
+    borderRadius: radius.round,
+    paddingHorizontal: 15,
+    paddingVertical: 9,
+  },
+  chipText: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.brand.gold,
+  },
+
+  // ── Dados Institucionais ──
+  infoRows: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    overflow: 'hidden',
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 13,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.border,
+  },
+  infoRowLast: {
+    borderBottomWidth: 0,
+  },
+  infoLabel: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+    flexShrink: 0,
+  },
+  infoValue: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+    textAlign: 'right',
+    flex: 1,
+    marginLeft: 8,
+  },
+  infoValueGreen: {
+    color: '#1d7a4a',
+  },
+
+  // ── Contact Cards ──
+  contactCards: {
+    gap: 8,
+  },
+  contactCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 13,
+    backgroundColor: colors.neutral.bg,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: 10,
+  },
+  contactIconBox: {
+    width: 36,
+    height: 36,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  contactCardText: {
+    flex: 1,
+  },
+  contactCardLabel: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  contactCardValue: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+  },
+  contactCardLink: {
+    color: colors.brand.gold,
+  },
+
+  // ── Bottom Spacer ──
+  bottomSpacer: {
+    height: 32,
+  },
 });


### PR DESCRIPTION
## Summary

- **OrgProfileScreen**: reconstruído seguindo o padrão do `StudentProfileScreen` — header navy fixo, banner 180px + logo 88×88 quadrado sobrepondo à esquerda, bloco de info com badges Verificada/Localização, botão "Ver Vagas Abertas", stats (Eventos | Voluntários | Avaliação), e seções Missão (caixa laranja), Áreas de Atuação (chips), Dados Institucionais (rows), Contato (icon cards), Galeria
- **OrgProfileEditScreen**: reconstruído seguindo o padrão do `StudentProfileEditScreen` — header X/Salvar, banner e logo editáveis com camera overlay, `KeyboardAwareScrollView`, seção Dados Cadastrais com labels público/obrigatório e CNPJ readonly, textareas Missão & Descrição com contadores, chips de Áreas de Atuação, `GalleryGrid` com props corretas (`editable`, `onDelete`, `onAdd`), e seção Segurança inline usando `changeOrgPassword` (endpoint `/organizations/me/change-password/`)

## Closes

Closes #16

## Test plan

- [ ] Abrir perfil da organização — verificar header, banner, logo, badges, stats, todas as seções
- [ ] Tocar em "Editar" — abre tela de edição corretamente
- [ ] Editar campos e salvar — sucesso/erro exibidos
- [ ] Alterar logo e banner via galeria do dispositivo
- [ ] Adicionar/remover fotos da galeria
- [ ] Alterar senha — validação e feedback corretos
- [ ] Pull-to-refresh na tela de perfil