### PR TITLE
fix: corrige validacao e status codes do login por cnpj (Issue #100)

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -144,7 +144,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
 
         # ── Login via email (estudante) — existing behaviour ──
         if self.username_field not in attrs:
-            raise AuthenticationFailed("É necessário informar e-mail ou CNPJ para realizar o login.")
+            raise serializers.ValidationError("É necessário informar e-mail ou CNPJ para realizar o login.")
 
         data = super().validate(attrs)
         user = self.user

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -110,13 +110,13 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             try:
                 org = OrganizationProfile.objects.get(cnpj=cnpj)
             except OrganizationProfile.DoesNotExist:
-                raise serializers.ValidationError("CNPJ ou senha inválidos.")
+                raise AuthenticationFailed("CNPJ ou senha inválidos.")
 
             if not org.user.is_active:
-                raise serializers.ValidationError("CNPJ ou senha inválidos.")
+                raise AuthenticationFailed("CNPJ ou senha inválidos.")
 
             if org.status != "approved":
-                raise serializers.ValidationError(
+                raise PermissionDenied(
                     "Organização pendente de aprovação. Aguarde a análise do administrador."
                 )
 
@@ -128,7 +128,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             user = authenticate(**authenticate_kwargs)
 
             if user is None or not user.is_active:
-                raise serializers.ValidationError("CNPJ ou senha inválidos.")
+                raise AuthenticationFailed("CNPJ ou senha inválidos.")
 
             self.user = user
 
@@ -143,6 +143,9 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             return data
 
         # ── Login via email (estudante) — existing behaviour ──
+        if self.username_field not in attrs:
+            raise AuthenticationFailed("É necessário informar e-mail ou CNPJ para realizar o login.")
+
         data = super().validate(attrs)
         user = self.user
 


### PR DESCRIPTION
## Resumo do PR
Este Pull Request corrige a validação de credenciais no login por CNPJ e ajusta a obrigatoriedade do campo e-mail. Antes, a API gerava o erro interno `KeyError: 'email'` quando um login era feito apenas com CNPJ e retornava códigos HTTP 400 (Bad Request) em vez de códigos de autenticação adequados (401/403) em falhas de credenciais.

---

## Alterações por Arquivo

### Backend

- **`backend/users/serializers.py`**
  - **Contexto / Antes:** O método genérico `super().validate(attrs)` do SimpleJWT estava sendo chamado mesmo sem a presença da chave `email` no dicionário, causando a quebra da aplicação. Além disso, falhas de senha ou contas pendentes disparavam `serializers.ValidationError` (HTTP 400).
  - **Alteração / Por quê:** 
    1. Adicionei uma trava de segurança `if self.username_field not in attrs:` antes de delegar a validação ao JWT padrão para resolver o `KeyError`.
    2. Substituí os `serializers.ValidationError` por `AuthenticationFailed` (HTTP 401 - Unauthorized) para falhas de credenciais/conta inativa.
    3. Substituí o erro de conta pendente por `PermissionDenied` (HTTP 403 - Forbidden). 
    Isso alinha o comportamento da API aos testes unitários exigidos na Issue e garante que o Frontend consiga interceptar o status HTTP correto para exibir os alertas na tela.

#Issues vinculadas
Fixes #100