### PR TITLE
feat(profiles): public student and organization profiles

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -18,6 +18,7 @@ from users.views import (
     student_register,
     organization_register,
     StudentProfileView,
+    StudentPublicProfileView,
     StudentProfileUpdateView,
     AvatarUploadView,
     BannerUploadView,
@@ -25,6 +26,7 @@ from users.views import (
     GalleryDeleteView,
     ChangePasswordView,
     OrganizationProfileView,
+    OrganizationPublicProfileView,
     OrganizationProfileUpdateView,
     OrgLogoUploadView,
     OrgBannerUploadView,
@@ -74,6 +76,8 @@ urlpatterns = [
     path("api/v1/students/me/gallery/<uuid:photo_id>/", GalleryDeleteView.as_view(), name="student-gallery-delete"),
     path("api/v1/students/me/change-password/", ChangePasswordView.as_view(), name="student-change-password"),
     path("api/v1/students/dashboard/", StudentDashboardView.as_view(), name="student-dashboard"),
+    # Perfil público de estudante (qualquer role autenticada)
+    path("api/v1/students/<uuid:pk>/", StudentPublicProfileView.as_view(), name="student-public-profile"),
     # Perfil da organização
     path("api/v1/organizations/me/", OrganizationProfileView.as_view(), name="org-profile-detail"),
     path("api/v1/organizations/me/update/", OrganizationProfileUpdateView.as_view(), name="org-profile-update"),
@@ -82,6 +86,8 @@ urlpatterns = [
     path("api/v1/organizations/me/gallery/", OrgGalleryUploadView.as_view(), name="org-gallery-upload"),
     path("api/v1/organizations/me/gallery/<uuid:photo_id>/", OrgGalleryDeleteView.as_view(), name="org-gallery-delete"),
     path("api/v1/organizations/me/change-password/", OrgChangePasswordView.as_view(), name="org-change-password"),
+    # Perfil público de organização (qualquer role autenticada)
+    path("api/v1/organizations/<uuid:pk>/", OrganizationPublicProfileView.as_view(), name="org-public-profile"),
     # Endpoints de verificação e moderação de organizações
     path(
         "api/v1/admin/organizations/",

--- a/backend/opportunities/serializers.py
+++ b/backend/opportunities/serializers.py
@@ -53,6 +53,7 @@ class OpportunitySerializer(serializers.ModelSerializer):
         org = obj.organization
         return {
             "id": str(org.id),
+            "user_id": str(org.user_id),
             "razao_social": org.razao_social,
         }
 
@@ -74,6 +75,7 @@ class OpportunityDetailSerializer(OpportunitySerializer):
             logo = request.build_absolute_uri(org.logo.url)
         return {
             "id": str(org.id),
+            "user_id": str(org.user_id),
             "razao_social": org.razao_social,
             "nome_fantasia": org.nome_fantasia,
             "logo": logo,

--- a/backend/users/tests/test_public_profiles.py
+++ b/backend/users/tests/test_public_profiles.py
@@ -1,0 +1,158 @@
+"""
+Testes dos perfis públicos (S4 — RF22/US2.12 e RF23/US2.13).
+
+Garante que:
+- usuários autenticados (qualquer role) veem o perfil público de outro estudante/org;
+- a representação espelha /me/ (read-only) — mesmos campos, sem ações de dono;
+- pk inexistente → 404, org pendente → 404, sem auth → 401;
+- o `id` retornado é o user.id (UUID, chave usada na rota e no resto da API).
+"""
+
+import uuid
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from users.models import OrganizationProfile, StudentProfile
+
+User = get_user_model()
+
+VALID_CNPJ = "11222333000181"
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def viewer(db):
+    """Usuário autenticado qualquer (estudante) que visualiza perfis alheios."""
+    return User.objects.create_user(
+        username="viewer",
+        email="viewer@test.com",
+        password="Senha123",
+        nome="Viewer",
+        role=User.Role.ESTUDANTE,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def student(db):
+    user = User.objects.create_user(
+        username="aluno",
+        email="aluno@test.com",
+        password="Senha123",
+        nome="Aluno Teste",
+        role=User.Role.ESTUDANTE,
+        is_active=True,
+    )
+    profile = StudentProfile.objects.create(
+        user=user,
+        universidade="UnB",
+        curso="Engenharia de Software",
+        matricula="190012345",
+        semestre_atual=5,
+        ano_conclusao=2027,
+        bio="Bio pública",
+        interesses=["educacao"],
+    )
+    return user, profile
+
+
+def _make_org(status="approved", email="ong@test.com", cnpj=VALID_CNPJ, username="ong"):
+    user = User.objects.create_user(
+        username=username,
+        email=email,
+        password="Senha123",
+        nome="ONG Teste",
+        role=User.Role.ORGANIZACAO,
+        is_active=status == "approved",
+    )
+    org = OrganizationProfile.objects.create(
+        user=user,
+        cnpj=cnpj,
+        razao_social="ONG Teste LTDA",
+        nome_fantasia="ONG Teste",
+        telefone="(11) 99999-9999",
+        nome_responsavel="Responsavel Teste",
+        site="https://ong.org",
+        status=status,
+    )
+    return user, org
+
+
+@pytest.mark.django_db
+class TestStudentPublicProfile:
+    def test_returns_public_data(self, client, viewer, student):
+        user, profile = student
+        client.force_authenticate(user=viewer)
+        resp = client.get(f"/api/v1/students/{user.id}/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["nome"] == "Aluno Teste"
+        assert data["curso"] == "Engenharia de Software"
+        assert data["universidade"] == "UnB"
+        assert data["bio"] == "Bio pública"
+        # id retornado == user.id (UUID, chave da rota)
+        assert data["id"] == str(user.id)
+
+    def test_mirrors_own_profile_fields(self, client, viewer, student):
+        """Mesma representação de /students/me/ (read-only)."""
+        user, _ = student
+        client.force_authenticate(user=viewer)
+        data = client.get(f"/api/v1/students/{user.id}/").json()
+        assert data["email"] == "aluno@test.com"
+        assert data["matricula"] == "190012345"
+
+    def test_unknown_pk_returns_404(self, client, viewer):
+        client.force_authenticate(user=viewer)
+        resp = client.get(f"/api/v1/students/{uuid.uuid4()}/")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client, student):
+        user, _ = student
+        resp = client.get(f"/api/v1/students/{user.id}/")
+        assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+class TestOrgPublicProfile:
+    def test_returns_public_data(self, client, viewer):
+        user, org = _make_org()
+        client.force_authenticate(user=viewer)
+        resp = client.get(f"/api/v1/organizations/{user.id}/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["razao_social"] == "ONG Teste LTDA"
+        assert data["site"] == "https://ong.org"
+        assert data["id"] == str(user.id)
+
+    def test_mirrors_own_profile_fields(self, client, viewer):
+        """Mesma representação de /organizations/me/ (read-only) — inclui contato."""
+        user, _ = _make_org()
+        client.force_authenticate(user=viewer)
+        data = client.get(f"/api/v1/organizations/{user.id}/").json()
+        assert data["email"] == "ong@test.com"
+        assert data["telefone"] == "(11) 99999-9999"
+        assert data["nome_responsavel"] == "Responsavel Teste"
+
+    def test_pending_org_returns_404(self, client, viewer):
+        user, _ = _make_org(
+            status="pending", email="pend@test.com", cnpj="11444777000161", username="pend"
+        )
+        client.force_authenticate(user=viewer)
+        resp = client.get(f"/api/v1/organizations/{user.id}/")
+        assert resp.status_code == 404
+
+    def test_unknown_pk_returns_404(self, client, viewer):
+        client.force_authenticate(user=viewer)
+        resp = client.get(f"/api/v1/organizations/{uuid.uuid4()}/")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client):
+        user, _ = _make_org()
+        resp = client.get(f"/api/v1/organizations/{user.id}/")
+        assert resp.status_code == 401

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -327,6 +327,22 @@ class StudentProfileView(APIView):
         return Response(serializer.data)
 
 
+class StudentPublicProfileView(APIView):
+    """GET /api/v1/students/<uuid:pk>/ — perfil público de um estudante (RF23/US2.13).
+
+    Mesma representação de /students/me/ (read-only). Sem ações de dono no front.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, pk):
+        profile = get_object_or_404(StudentProfile, user_id=pk)
+        serializer = StudentProfileDetailSerializer(
+            profile, context={"request": request}
+        )
+        return Response(serializer.data)
+
+
 class StudentProfileUpdateView(APIView):
     """PATCH /api/v1/students/me/update/ — atualiza dados do perfil."""
 
@@ -493,6 +509,24 @@ class OrganizationProfileView(APIView):
                 {"detail": "Perfil de organização não encontrado."},
                 status=status.HTTP_404_NOT_FOUND,
             )
+        serializer = OrganizationProfileDetailSerializer(
+            profile, context={"request": request}
+        )
+        return Response(serializer.data)
+
+
+class OrganizationPublicProfileView(APIView):
+    """GET /api/v1/organizations/<uuid:pk>/ — perfil público de uma org (RF22/US2.12).
+
+    Só orgs aprovadas são visíveis — pending/rejected retornam 404.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, pk):
+        profile = get_object_or_404(
+            OrganizationProfile, user_id=pk, status="approved"
+        )
         serializer = OrganizationProfileDetailSerializer(
             profile, context={"request": request}
         )

--- a/context/API.md
+++ b/context/API.md
@@ -50,6 +50,14 @@
 | DELETE | `/students/me/gallery/{photo_id}/` | Remove foto |
 | POST | `/students/me/change-password/` | Troca de senha |
 
+### Perfis públicos (`IsAuthenticated`, qualquer role)
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/students/{user_id}/` | Perfil do estudante — mesma representação de `/students/me/` (read-only). 404 se inexistente |
+| GET | `/organizations/{user_id}/` | Perfil da org — mesma representação de `/organizations/me/` (read-only). Só `status=approved`; pending/rejected/inexistente → 404 |
+
+Reusam os Detail serializers de `/me/` (mesmos campos, incl. contato). Lookup por `user_id` (UUID do User), mesma chave de `id` em `/me/`, login e registro. Payload de oportunidade expõe `organization.user_id` para navegação.
+
 ### Organização — perfil próprio (`IsAuthenticated + IsOrganizacao`)
 | Method | Path | Description |
 |--------|------|-------------|

--- a/context/GOTCHAS.md
+++ b/context/GOTCHAS.md
@@ -43,6 +43,9 @@ Default DRF é `IsAuthenticated`. Esquecer `@permission_classes([AllowAny])` →
 ### Login por CNPJ
 CNPJ armazenado como dígitos puros. Strip da máscara antes de validar/buscar.
 
+### `id` de profile ≠ `user.id`
+`StudentProfile`/`OrganizationProfile` têm PK **inteiro** (AutoField). O `id` canônico exposto pela API (`/me/`, login, registro, detail serializers via `source="user.id"`) é o **UUID do User**. Rotas públicas de perfil keyam por `user_id`, não pelo PK do profile. `opportunity.organization.id` é o PK inteiro do profile (legado) — para navegar ao perfil público use `organization.user_id`.
+
 ---
 
 ## Frontend — Expo / React Native

--- a/frontend/src/components/ui/OpportunityCard.tsx
+++ b/frontend/src/components/ui/OpportunityCard.tsx
@@ -7,6 +7,7 @@ import { radius } from '../../theme/spacing';
 
 interface OrganizationData {
   id?: string;
+  user_id?: string;
   razao_social: string;
 }
 
@@ -35,6 +36,7 @@ interface OpportunityCardProps {
   onSave: () => void;
   onPress: () => void;
   onApply?: () => void;
+  onOrgPress?: () => void;
 }
 
 const AREA_LABELS: Record<string, string> = {
@@ -66,6 +68,7 @@ export default function OpportunityCard({
   onSave,
   onPress,
   onApply,
+  onOrgPress,
 }: OpportunityCardProps) {
   const accent = categoryColor(opportunity.area);
   const filledRatio =
@@ -99,7 +102,13 @@ export default function OpportunityCard({
         </View>
 
         <Text style={styles.title}>{opportunity.title}</Text>
-        <Text style={styles.orgName}>{opportunity.organization.razao_social}</Text>
+        {onOrgPress ? (
+          <TouchableOpacity testID="card-org-link" onPress={onOrgPress} hitSlop={6} activeOpacity={0.7}>
+            <Text style={[styles.orgName, styles.orgNameLink]}>{opportunity.organization.razao_social}</Text>
+          </TouchableOpacity>
+        ) : (
+          <Text style={styles.orgName}>{opportunity.organization.razao_social}</Text>
+        )}
 
         {/* Meta row — workload + (location | date), Figma 32:2 */}
         <View style={styles.metaRow}>
@@ -196,6 +205,10 @@ const styles = StyleSheet.create({
     fontFamily: fontFamilies.dmSansRegular,
     fontSize: 13,
     color: colors.text.secondary,
+  },
+  orgNameLink: {
+    color: colors.brand.navy,
+    textDecorationLine: 'underline',
   },
   metaRow: {
     flexDirection: 'row',

--- a/frontend/src/navigation/OrgStack.tsx
+++ b/frontend/src/navigation/OrgStack.tsx
@@ -6,6 +6,8 @@ import OrgProfileScreen from '../screens/organization/OrgProfileScreen';
 import OrgProfileEditScreen from '../screens/organization/OrgProfileEditScreen';
 import OpportunityApplicantsScreen from '../screens/organization/OpportunityApplicantsScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
+import PublicStudentProfileScreen from '../screens/student/PublicStudentProfileScreen';
+import PublicOrgProfileScreen from '../screens/organization/PublicOrgProfileScreen';
 
 export type OrgStackParamList = {
   OrgHome: undefined;
@@ -14,6 +16,8 @@ export type OrgStackParamList = {
   OrgProfileEdit: undefined;
   OpportunityApplicants: { opportunityId: string; opportunityTitle: string };
   Notifications: undefined;
+  PublicStudentProfile: { userId: string };
+  PublicOrgProfile: { orgId: string };
 };
 
 const Stack = createNativeStackNavigator<OrgStackParamList>();
@@ -27,6 +31,8 @@ export default function OrgStack() {
       <Stack.Screen name="OrgProfileEdit" component={OrgProfileEditScreen} options={{ title: 'Editar Perfil' }} />
       <Stack.Screen name="OpportunityApplicants" component={OpportunityApplicantsScreen} options={{ title: 'Candidatos' }} />
       <Stack.Screen name="Notifications" component={NotificationsScreen} options={{ headerShown: false }} />
+      <Stack.Screen name="PublicStudentProfile" component={PublicStudentProfileScreen} options={{ headerShown: false }} />
+      <Stack.Screen name="PublicOrgProfile" component={PublicOrgProfileScreen} options={{ headerShown: false }} />
     </Stack.Navigator>
   );
 }

--- a/frontend/src/navigation/StudentStack.tsx
+++ b/frontend/src/navigation/StudentStack.tsx
@@ -8,6 +8,8 @@ import GalleryFullScreen from '../screens/student/GalleryFullScreen';
 import OpportunityDetailScreen from '../screens/student/OpportunityDetailScreen';
 import MyApplicationsScreen from '../screens/student/MyApplicationsScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
+import PublicStudentProfileScreen from '../screens/student/PublicStudentProfileScreen';
+import PublicOrgProfileScreen from '../screens/organization/PublicOrgProfileScreen';
 
 export type StudentStackParamList = {
   StudentHome: undefined;
@@ -17,6 +19,8 @@ export type StudentStackParamList = {
   OpportunityDetail: { id: string };
   MyApplications: undefined;
   Notifications: undefined;
+  PublicStudentProfile: { userId: string };
+  PublicOrgProfile: { orgId: string };
 };
 
 const Stack = createNativeStackNavigator<StudentStackParamList>();
@@ -57,6 +61,16 @@ export default function StudentStack() {
       <Stack.Screen
         name="Notifications"
         component={NotificationsScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="PublicStudentProfile"
+        component={PublicStudentProfileScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="PublicOrgProfile"
+        component={PublicOrgProfileScreen}
         options={{ headerShown: false }}
       />
     </Stack.Navigator>

--- a/frontend/src/screens/organization/PublicOrgProfileScreen.tsx
+++ b/frontend/src/screens/organization/PublicOrgProfileScreen.tsx
@@ -1,0 +1,773 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+import { useAuth } from '../../context/AuthContext';
+import GalleryPreview from '../../components/profile/GalleryPreview';
+import ImageViewer from '../../components/profile/ImageViewer';
+import { colors } from '../../theme/colors';
+import { radius, shadows } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+import { getOrgPublicProfile, OrgProfileData } from '../../services/api';
+import { INTERESSE_OPTIONS } from '../../constants/interests';
+
+function isAuthError(e: unknown): e is { status: number } {
+  return typeof e === 'object' && e !== null && 'status' in e && (e as any).status === 401;
+}
+
+const AREA_LABELS: Record<string, string> = {};
+INTERESSE_OPTIONS.forEach((opt) => { AREA_LABELS[opt.id] = opt.label; });
+
+export default function PublicOrgProfileScreen() {
+  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
+  const { orgId } = route.params ?? {};
+  const { accessToken, tryRefreshSession } = useAuth();
+
+  const [profile, setProfile] = useState<OrgProfileData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [viewerVisible, setViewerVisible] = useState(false);
+  const [viewerUrl, setViewerUrl] = useState('');
+
+  const loadProfile = useCallback(async () => {
+    if (!accessToken || !orgId) return;
+    try {
+      setErrorMessage('');
+      const data = await getOrgPublicProfile(accessToken, orgId);
+      setProfile(data);
+    } catch (e) {
+      if (isAuthError(e)) {
+        const newToken = await tryRefreshSession();
+        if (newToken) {
+          try {
+            const data = await getOrgPublicProfile(newToken, orgId);
+            setProfile(data);
+            return;
+          } catch {
+            setErrorMessage('Não foi possível carregar o perfil. Tente novamente.');
+          }
+        }
+        return;
+      }
+      setErrorMessage('Não foi possível carregar o perfil. Tente novamente.');
+    } finally {
+      setIsLoading(false);
+      setRefreshing(false);
+    }
+  }, [accessToken, orgId, tryRefreshSession]);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    loadProfile();
+  }
+
+  function getInitial(name: string): string {
+    return name ? name.charAt(0).toUpperCase() : '?';
+  }
+
+  // ── Loading State ──
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.brand.gold} />
+        <Text style={styles.loadingText}>Carregando perfil...</Text>
+      </View>
+    );
+  }
+
+  // ── Error State ──
+  if (errorMessage && !profile) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Ionicons name="information-circle" size={48} color={colors.text.secondary} />
+        <Text style={styles.errorBanner}>{errorMessage}</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={loadProfile}>
+          <Text style={styles.retryButtonText}>Tentar novamente</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (!profile) return null;
+
+  const displayName = profile.nome_fantasia || profile.razao_social;
+  const openPositionsCount = (profile.open_positions as any[])?.length ?? 0;
+
+  return (
+    <View style={styles.root}>
+      {/* ═══ FIXED: Navy Header ═══ */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.headerBackButton}
+          onPress={() => navigation.goBack()}
+          activeOpacity={0.7}
+          testID="public-org-profile-back-button"
+        >
+          <Ionicons name="arrow-back" size={20} color={colors.neutral.white} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Perfil da Organização</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {/* ═══ SCROLLABLE: Profile Content ═══ */}
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+      >
+        {/* Banner */}
+        <TouchableOpacity
+          style={styles.bannerContainer}
+          onPress={() => {
+            if (profile.banner_url) {
+              setViewerUrl(profile.banner_url);
+              setViewerVisible(true);
+            }
+          }}
+          activeOpacity={profile.banner_url ? 0.8 : 1}
+          disabled={!profile.banner_url}
+          accessibilityLabel="Ver banner"
+        >
+          {profile.banner_url ? (
+            <Image source={{ uri: profile.banner_url }} style={styles.bannerImage} />
+          ) : (
+            <View style={[styles.bannerImage, styles.bannerPlaceholder]} />
+          )}
+        </TouchableOpacity>
+
+        {/* ═══ Profile Info Block (white, full-width) ═══ */}
+        <View style={styles.profileBlock}>
+          {/* Logo (overlapping banner, left-aligned) */}
+          <View style={styles.logoRow}>
+            <TouchableOpacity
+              style={styles.logoOuter}
+              onPress={() => {
+                if (profile.logo_url) {
+                  setViewerUrl(profile.logo_url);
+                  setViewerVisible(true);
+                }
+              }}
+              activeOpacity={profile.logo_url ? 0.8 : 1}
+              disabled={!profile.logo_url}
+              accessibilityLabel="Ver logo"
+            >
+              {profile.logo_url ? (
+                <Image source={{ uri: profile.logo_url }} style={styles.logoImage} />
+              ) : (
+                <View style={styles.logoPlaceholder}>
+                  <Text style={styles.logoInitial}>{getInitial(displayName)}</Text>
+                </View>
+              )}
+            </TouchableOpacity>
+
+            {/* Share button */}
+            <TouchableOpacity style={styles.iconButton} activeOpacity={0.7}>
+              <Ionicons name="share-outline" size={16} color={colors.text.primary} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Name */}
+          <Text style={styles.orgName}>{displayName}</Text>
+
+          {/* Category / Razão Social subtitle */}
+          {profile.nome_fantasia && profile.razao_social ? (
+            <Text style={styles.orgCategory}>{profile.razao_social}</Text>
+          ) : null}
+
+          {/* Badges: Verified + Location */}
+          <View style={styles.badgesRow}>
+            <View style={styles.verifiedBadge}>
+              <Text style={styles.verifiedText}>✓ Verificada</Text>
+            </View>
+            {profile.endereco ? (
+              <View style={styles.locationBadge}>
+                <Text style={styles.locationText}>📍 {profile.endereco}</Text>
+              </View>
+            ) : null}
+          </View>
+
+          {/* CTA Row */}
+          <View style={styles.ctaRow}>
+            <TouchableOpacity
+              style={styles.primaryButton}
+              activeOpacity={0.8}
+              testID="org-view-positions-button"
+            >
+              <Text style={styles.primaryButtonText}>
+                {'Ver Vagas Abertas' + (openPositionsCount > 0 ? ` (${openPositionsCount})` : '')}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.bookmarkButton} activeOpacity={0.7}>
+              <Ionicons name="bookmark-outline" size={20} color={colors.text.primary} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Stats */}
+          <View style={styles.statsRow}>
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{profile.stats.total_events}</Text>
+              <Text style={styles.statLabel}>Eventos</Text>
+            </View>
+            <View style={styles.statDivider} />
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{profile.stats.total_volunteers}</Text>
+              <Text style={styles.statLabel}>Voluntários</Text>
+            </View>
+            <View style={styles.statDivider} />
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{profile.stats.rating}</Text>
+              <Text style={styles.statLabel}>Avaliação</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* ═══ Missão ═══ */}
+        {(profile.mission || profile.full_description) ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Missão</Text>
+            {profile.mission ? (
+              <View style={styles.missionBox}>
+                <Text style={styles.missionBoxLabel}>NOSSA MISSÃO</Text>
+                <Text style={styles.missionBoxText}>{`"${profile.mission}"`}</Text>
+              </View>
+            ) : null}
+            {profile.full_description ? (
+              <Text style={styles.descriptionText}>{profile.full_description}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* ═══ Áreas de Atuação ═══ */}
+        {profile.areas_de_atuacao && profile.areas_de_atuacao.length > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Áreas de Atuação</Text>
+            <View style={styles.chipsRow}>
+              {profile.areas_de_atuacao.map((area) => (
+                <View key={area} style={styles.chip}>
+                  <Text style={styles.chipText}>
+                    {AREA_LABELS[area] || area.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {/* ═══ Dados Institucionais ═══ */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Dados Institucionais</Text>
+          <View style={styles.infoRows}>
+            {profile.razao_social ? (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Razão Social</Text>
+                <Text style={styles.infoValue} numberOfLines={1}>{profile.razao_social}</Text>
+              </View>
+            ) : null}
+            {profile.nome_responsavel ? (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Responsável</Text>
+                <Text style={styles.infoValue}>{profile.nome_responsavel}</Text>
+              </View>
+            ) : null}
+            {profile.endereco ? (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Localização</Text>
+                <Text style={styles.infoValue}>{profile.endereco}</Text>
+              </View>
+            ) : null}
+            <View style={[styles.infoRow, styles.infoRowLast]}>
+              <Text style={styles.infoLabel}>Status</Text>
+              <Text style={[styles.infoValue, styles.infoValueGreen]}>✓ Aprovada pela Liaison</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* ═══ Contato ═══ */}
+        {(profile.email || profile.telefone || profile.site) ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Contato</Text>
+            <View style={styles.contactCards}>
+              {profile.email ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.navy }]}>
+                    <Ionicons name="mail-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>E-MAIL</Text>
+                    <Text style={styles.contactCardValue}>{profile.email}</Text>
+                  </View>
+                </View>
+              ) : null}
+              {profile.telefone ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.navy }]}>
+                    <Ionicons name="call-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>TELEFONE</Text>
+                    <Text style={styles.contactCardValue}>{profile.telefone}</Text>
+                  </View>
+                </View>
+              ) : null}
+              {profile.site ? (
+                <View style={styles.contactCard}>
+                  <View style={[styles.contactIconBox, { backgroundColor: colors.brand.gold }]}>
+                    <Ionicons name="globe-outline" size={16} color={colors.neutral.white} />
+                  </View>
+                  <View style={styles.contactCardText}>
+                    <Text style={styles.contactCardLabel}>SITE</Text>
+                    <Text style={[styles.contactCardValue, styles.contactCardLink]}>{profile.site}</Text>
+                  </View>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+
+        {/* ═══ Galeria ═══ */}
+        {profile.gallery && profile.gallery.length > 0 ? (
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <Text style={styles.sectionTitle}>Álbum de Eventos</Text>
+              <Text style={styles.sectionSubtext}>{profile.gallery.length} fotos</Text>
+            </View>
+            <GalleryPreview
+              photos={profile.gallery}
+              onPhotoPress={(photo) => {
+                if (photo.image_url) {
+                  setViewerUrl(photo.image_url);
+                  setViewerVisible(true);
+                }
+              }}
+            />
+          </View>
+        ) : null}
+
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
+
+      {/* ═══ Image Viewer Modal ═══ */}
+      <ImageViewer
+        visible={viewerVisible}
+        imageUrl={viewerUrl}
+        onClose={() => setViewerVisible(false)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+  },
+
+  // ── Loading / Error ──
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  loadingText: {
+    ...typography.body,
+    color: colors.text.secondary,
+    marginTop: 12,
+  },
+  errorBanner: {
+    ...typography.body,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: 16,
+    marginBottom: 20,
+  },
+  retryButton: {
+    backgroundColor: colors.brand.gold,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: radius.sm,
+  },
+  retryButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 15,
+    color: colors.neutral.white,
+  },
+
+  // ── Header ──
+  header: {
+    backgroundColor: colors.brand.navy,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 50,
+    paddingBottom: 14,
+  },
+  headerBackButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 18,
+    color: colors.neutral.white,
+  },
+  headerSpacer: {
+    width: 40,
+  },
+
+  // ── Scroll ──
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 40,
+  },
+
+  // ── Banner ──
+  bannerContainer: {
+    width: '100%',
+    height: 180,
+  },
+  bannerImage: {
+    width: '100%',
+    height: 180,
+  },
+  bannerPlaceholder: {
+    backgroundColor: '#1a2744',
+  },
+
+  // ── Profile Block ──
+  profileBlock: {
+    backgroundColor: colors.neutral.white,
+    paddingHorizontal: 16,
+    paddingBottom: 20,
+  },
+  logoRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    marginTop: -44,
+    marginBottom: 8,
+  },
+  logoOuter: {
+    width: 88,
+    height: 88,
+    borderRadius: 16,
+    borderWidth: 4,
+    borderColor: colors.neutral.white,
+    overflow: 'hidden',
+    ...shadows.card,
+  },
+  logoImage: {
+    width: '100%',
+    height: '100%',
+  },
+  logoPlaceholder: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colors.brand.navy,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logoInitial: {
+    fontFamily: typography.h1.fontFamily,
+    fontSize: 28,
+    color: colors.neutral.white,
+    letterSpacing: 1,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 52,
+  },
+
+  // ── Name / Category ──
+  orgName: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 21,
+    color: colors.text.primary,
+    marginBottom: 4,
+  },
+  orgCategory: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginBottom: 12,
+  },
+
+  // ── Badges ──
+  badgesRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 16,
+    flexWrap: 'wrap',
+  },
+  verifiedBadge: {
+    backgroundColor: 'rgba(29,122,74,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(29,122,74,0.2)',
+    borderRadius: radius.round,
+    paddingHorizontal: 13,
+    paddingVertical: 5,
+  },
+  verifiedText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: '#1d7a4a',
+  },
+  locationBadge: {
+    backgroundColor: 'rgba(26,39,68,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(26,39,68,0.15)',
+    borderRadius: radius.round,
+    paddingHorizontal: 13,
+    paddingVertical: 5,
+  },
+  locationText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.brand.navy,
+  },
+
+  // ── CTA Row ──
+  ctaRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 16,
+  },
+  primaryButton: {
+    flex: 1,
+    height: 48,
+    backgroundColor: colors.brand.navy,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 14,
+    color: colors.neutral.white,
+  },
+  bookmarkButton: {
+    width: 48,
+    height: 48,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // ── Stats ──
+  statsRow: {
+    flexDirection: 'row',
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.neutral.border,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statNumber: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 22,
+    color: colors.text.primary,
+  },
+  statLabel: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    backgroundColor: colors.neutral.border,
+  },
+
+  // ── Sections ──
+  section: {
+    marginTop: 2,
+    backgroundColor: colors.neutral.white,
+    padding: 16,
+  },
+  sectionHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 16,
+    color: colors.text.primary,
+    marginBottom: 12,
+  },
+  sectionSubtext: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+    marginBottom: 12,
+  },
+
+  // ── Mission ──
+  missionBox: {
+    backgroundColor: '#fdf5ec',
+    borderWidth: 1,
+    borderColor: 'rgba(212,129,58,0.2)',
+    borderRadius: 10,
+    padding: 17,
+    marginBottom: 16,
+  },
+  missionBoxLabel: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.brand.gold,
+    letterSpacing: 0.6,
+    marginBottom: 8,
+  },
+  missionBoxText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: '#3a4560',
+    lineHeight: 22,
+  },
+  descriptionText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    color: '#3a4560',
+    lineHeight: 23,
+  },
+
+  // ── Chips ──
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    backgroundColor: colors.accent.lightBg,
+    borderWidth: 1,
+    borderColor: colors.brand.gold,
+    borderRadius: radius.round,
+    paddingHorizontal: 15,
+    paddingVertical: 9,
+  },
+  chipText: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.brand.gold,
+  },
+
+  // ── Dados Institucionais ──
+  infoRows: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    overflow: 'hidden',
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 13,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.border,
+  },
+  infoRowLast: {
+    borderBottomWidth: 0,
+  },
+  infoLabel: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+    flexShrink: 0,
+  },
+  infoValue: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+    textAlign: 'right',
+    flex: 1,
+    marginLeft: 8,
+  },
+  infoValueGreen: {
+    color: '#1d7a4a',
+  },
+
+  // ── Contact Cards ──
+  contactCards: {
+    gap: 8,
+  },
+  contactCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 13,
+    backgroundColor: colors.neutral.bg,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: 10,
+  },
+  contactIconBox: {
+    width: 36,
+    height: 36,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  contactCardText: {
+    flex: 1,
+  },
+  contactCardLabel: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  contactCardValue: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+  },
+  contactCardLink: {
+    color: colors.brand.gold,
+  },
+
+  // ── Bottom Spacer ──
+  bottomSpacer: {
+    height: 32,
+  },
+});

--- a/frontend/src/screens/student/HomeScreen.tsx
+++ b/frontend/src/screens/student/HomeScreen.tsx
@@ -63,7 +63,7 @@ interface CategoryData {
 interface OpportunityData {
   id: string;
   title: string;
-  organization: { id?: string; razao_social: string };
+  organization: { id?: string; user_id?: string; razao_social: string };
   area: string;
   description: string;
   workload_value: number;
@@ -350,6 +350,11 @@ export default function StudentHomeScreen() {
               onSave={() => handleSave(item)}
               onPress={() => navigation.navigate('OpportunityDetail', { id: item.id })}
               onApply={() => navigation.navigate('OpportunityDetail', { id: item.id })}
+              onOrgPress={
+                item.organization.user_id
+                  ? () => navigation.navigate('PublicOrgProfile', { orgId: item.organization.user_id })
+                  : undefined
+              }
             />
           </View>
         )}

--- a/frontend/src/screens/student/OpportunityDetailScreen.tsx
+++ b/frontend/src/screens/student/OpportunityDetailScreen.tsx
@@ -53,6 +53,7 @@ const MONTHS = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', '
 
 interface Organization {
   id: string;
+  user_id?: string;
   razao_social: string;
   nome_fantasia?: string;
   logo?: string | null;
@@ -227,6 +228,10 @@ export default function OpportunityDetailScreen() {
     ? `${shortDate(opportunity.start_date)}${opportunity.end_date ? ` — ${shortDate(opportunity.end_date)}` : ''}`
     : '';
   const sessLabel = sessionLabel(opportunity.session_duration);
+  const orgId = opportunity.organization.user_id;
+  const openOrgProfile = () => {
+    if (orgId) navigation.navigate('PublicOrgProfile', { orgId });
+  };
   const courses = [
     ...(opportunity.accepts_any_course ? ['Qualquer curso'] : []),
     ...(opportunity.preferred_courses ?? []),
@@ -297,7 +302,13 @@ export default function OpportunityDetailScreen() {
 
           <Text style={styles.title}>{opportunity.title}</Text>
 
-          <View style={styles.heroOrgRow}>
+          <TouchableOpacity
+            testID="hero-org-link"
+            style={styles.heroOrgRow}
+            onPress={openOrgProfile}
+            disabled={!orgId}
+            activeOpacity={0.7}
+          >
             {opportunity.organization.logo ? (
               <Image source={{ uri: opportunity.organization.logo }} style={styles.heroOrgLogo} />
             ) : (
@@ -306,7 +317,7 @@ export default function OpportunityDetailScreen() {
               </View>
             )}
             <Text style={styles.heroOrgName}>{orgName}</Text>
-          </View>
+          </TouchableOpacity>
 
           <View style={styles.heroDivider} />
 
@@ -462,7 +473,13 @@ export default function OpportunityDetailScreen() {
 
         {/* Organização */}
         <Card title="Organização">
-          <View style={styles.orgCardRow}>
+          <TouchableOpacity
+            testID="org-card-link"
+            style={styles.orgCardRow}
+            onPress={openOrgProfile}
+            disabled={!orgId}
+            activeOpacity={0.7}
+          >
             {opportunity.organization.logo ? (
               <Image source={{ uri: opportunity.organization.logo }} style={styles.orgLogoLg} />
             ) : (
@@ -474,7 +491,10 @@ export default function OpportunityDetailScreen() {
               <Text style={styles.orgNameLg}>{orgName}</Text>
               <Text style={styles.orgMetaLg}>{opportunity.organization.razao_social}</Text>
             </View>
-          </View>
+            {orgId ? (
+              <Ionicons name="chevron-forward" size={20} color={colors.text.secondary} />
+            ) : null}
+          </TouchableOpacity>
           {!!opportunity.organization.mission && (
             <Text style={styles.orgMission}>{opportunity.organization.mission}</Text>
           )}

--- a/frontend/src/screens/student/PublicStudentProfileScreen.tsx
+++ b/frontend/src/screens/student/PublicStudentProfileScreen.tsx
@@ -1,0 +1,737 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+import { useAuth } from '../../context/AuthContext';
+import GalleryPreview from '../../components/profile/GalleryPreview';
+import ImageViewer from '../../components/profile/ImageViewer';
+import { colors } from '../../theme/colors';
+import { radius, shadows } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+import { getStudentPublicProfile, ProfileData } from '../../services/api';
+
+function isAuthError(e: unknown): e is { status: number } {
+  return typeof e === 'object' && e !== null && 'status' in e && (e as any).status === 401;
+}
+
+export default function PublicStudentProfileScreen() {
+  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
+  const { userId } = route.params ?? {};
+  const { accessToken, tryRefreshSession } = useAuth();
+
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [viewerVisible, setViewerVisible] = useState(false);
+  const [viewerUrl, setViewerUrl] = useState('');
+
+  const loadProfile = useCallback(async () => {
+    if (!accessToken || !userId) return;
+    try {
+      setErrorMessage('');
+      const data = await getStudentPublicProfile(accessToken, userId);
+      setProfile(data);
+    } catch (e) {
+      if (isAuthError(e)) {
+        const newToken = await tryRefreshSession();
+        if (newToken) {
+          try {
+            const data = await getStudentPublicProfile(newToken, userId);
+            setProfile(data);
+            return;
+          } catch {
+            setErrorMessage('Não foi possível carregar o perfil. Tente novamente.');
+          }
+        }
+        return;
+      }
+      setErrorMessage('Não foi possível carregar o perfil. Tente novamente.');
+    } finally {
+      setIsLoading(false);
+      setRefreshing(false);
+    }
+  }, [accessToken, userId, tryRefreshSession]);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    loadProfile();
+  }
+
+  function getInitial(name: string): string {
+    return name ? name.charAt(0).toUpperCase() : '?';
+  }
+
+  function formatTurno(turno: string | null): string {
+    const map: Record<string, string> = {
+      matutino: 'Matutino',
+      vespertino: 'Vespertino',
+      noturno: 'Noturno',
+      integral: 'Integral',
+    };
+    return turno ? map[turno] || turno : '';
+  }
+
+  function formatSemestre(semestre: number | null): string {
+    if (!semestre) return '';
+    return `${semestre}º semestre`;
+  }
+
+  // ── Loading State ──
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.brand.gold} />
+        <Text style={styles.loadingText}>Carregando perfil...</Text>
+      </View>
+    );
+  }
+
+  // ── Error State ──
+  if (errorMessage && !profile) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Ionicons name="information-circle" size={48} color={colors.text.secondary} />
+        <Text style={styles.errorBanner}>{errorMessage}</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={loadProfile}>
+          <Text style={styles.retryButtonText}>Tentar novamente</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (!profile) return null;
+
+  const progressFraction = profile.stats.total_hours_required > 0
+    ? Math.min(profile.stats.total_hours_completed / profile.stats.total_hours_required, 1)
+    : 0;
+
+  return (
+    <View style={styles.root}>
+      {/* ═══ FIXED: Navy Header ═══ */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.headerBackButton}
+          onPress={() => navigation.goBack()}
+          activeOpacity={0.7}
+          testID="public-profile-back-button"
+        >
+          <Ionicons name="arrow-back" size={20} color={colors.neutral.white} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Perfil do Estudante</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {/* ═══ SCROLLABLE: Profile Content ═══ */}
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+      >
+        {/* Banner */}
+        <TouchableOpacity
+          style={styles.bannerContainer}
+          onPress={() => {
+            if (profile.banner_url) {
+              setViewerUrl(profile.banner_url);
+              setViewerVisible(true);
+            }
+          }}
+          activeOpacity={profile.banner_url ? 0.8 : 1}
+          disabled={!profile.banner_url}
+          accessibilityLabel="Ver banner"
+        >
+          {profile.banner_url ? (
+            <Image source={{ uri: profile.banner_url }} style={styles.bannerImage} />
+          ) : (
+            <View style={[styles.bannerImage, styles.bannerPlaceholder]} />
+          )}
+        </TouchableOpacity>
+
+        {/* Avatar (overlapping banner) */}
+        <View style={styles.avatarWrapper}>
+          <TouchableOpacity
+            style={styles.avatarOuter}
+            onPress={() => {
+              if (profile.avatar_url) {
+                setViewerUrl(profile.avatar_url);
+                setViewerVisible(true);
+              }
+            }}
+            activeOpacity={profile.avatar_url ? 0.8 : 1}
+            disabled={!profile.avatar_url}
+            accessibilityLabel="Ver foto de perfil"
+          >
+            {profile.avatar_url ? (
+              <Image source={{ uri: profile.avatar_url }} style={styles.avatarImage} />
+            ) : (
+              <View style={styles.avatarPlaceholder}>
+                <Text style={styles.avatarInitial}>{getInitial(profile.nome)}</Text>
+              </View>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* Share Button (top-right area) */}
+        <TouchableOpacity
+          style={styles.shareButton}
+          activeOpacity={0.7}
+        >
+          <Ionicons name="share-outline" size={20} color={colors.brand.gold} />
+        </TouchableOpacity>
+
+        {/* ═══ White Card: Profile Info ═══ */}
+        <View style={styles.card}>
+          {/* Name */}
+          <Text style={styles.name}>{profile.nome}</Text>
+
+          {/* Course Info */}
+          <Text style={styles.courseInfo}>
+            {profile.curso} · {profile.universidade}
+            {profile.semestre_atual ? ` · ${formatSemestre(profile.semestre_atual)}` : ''}
+          </Text>
+
+          {/* Badge */}
+          <View style={styles.badge}>
+            <Text style={styles.badgeEmoji}>🎓</Text>
+            <Text style={styles.badgeText}>Estudante</Text>
+          </View>
+
+          {/* Progress Bar */}
+          <View style={styles.progressSection}>
+            <View style={styles.progressHeader}>
+              <Text style={styles.progressLabel}>Horas de extensão</Text>
+              <Text style={styles.progressValue}>
+                {profile.stats.total_hours_completed}h / {profile.stats.total_hours_required}h
+              </Text>
+            </View>
+            <View style={styles.progressBarBg}>
+              <View
+                style={[styles.progressBarFill, { width: `${progressFraction * 100}%` }]}
+              />
+            </View>
+          </View>
+
+          {/* Stats */}
+          <View style={styles.statsRow}>
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{profile.stats.total_hours_completed}h</Text>
+              <Text style={styles.statLabel}>Horas de Extensão</Text>
+            </View>
+            <View style={styles.statDivider} />
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{profile.stats.total_events}</Text>
+              <Text style={styles.statLabel}>Eventos</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* ═══ Biografia ═══ */}
+        {profile.bio ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Biografia</Text>
+            <Text style={styles.bioText}>{profile.bio}</Text>
+          </View>
+        ) : null}
+
+        {/* ═══ Áreas de Interesse ═══ */}
+        {profile.interesses && profile.interesses.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Áreas de Interesse</Text>
+            <View style={styles.chipsRow}>
+              {profile.interesses.map((interesse) => (
+                <View key={interesse} style={styles.chip}>
+                  <Text style={styles.chipText}>
+                    {interesse.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* ═══ Dados Acadêmicos ═══ */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Dados Acadêmicos</Text>
+          <View style={styles.academicRows}>
+            <View style={styles.academicRow}>
+              <Text style={styles.academicLabel}>Universidade</Text>
+              <Text style={styles.academicValue}>{profile.universidade}</Text>
+            </View>
+            <View style={styles.academicRow}>
+              <Text style={styles.academicLabel}>Curso</Text>
+              <Text style={styles.academicValue}>{profile.curso}</Text>
+            </View>
+            <View style={styles.academicRow}>
+              <Text style={styles.academicLabel}>Matrícula</Text>
+              <Text style={styles.academicValue}>{profile.matricula}</Text>
+            </View>
+            {profile.semestre_atual && (
+              <View style={styles.academicRow}>
+                <Text style={styles.academicLabel}>Semestre</Text>
+                <Text style={styles.academicValue}>{formatSemestre(profile.semestre_atual)}</Text>
+              </View>
+            )}
+            {profile.turno && (
+              <View style={styles.academicRow}>
+                <Text style={styles.academicLabel}>Turno</Text>
+                <Text style={styles.academicValue}>{formatTurno(profile.turno)}</Text>
+              </View>
+            )}
+            {profile.ano_conclusao && (
+              <View style={[styles.academicRow, styles.academicRowLast]}>
+                <Text style={styles.academicLabel}>Ano conclusão</Text>
+                <Text style={styles.academicValue}>{profile.ano_conclusao}</Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {/* ═══ Galeria de Fotos ═══ */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Galeria de Fotos</Text>
+          <GalleryPreview
+            photos={profile.gallery}
+            onPhotoPress={(photo) => {
+              if (photo.image_url) {
+                setViewerUrl(photo.image_url);
+                setViewerVisible(true);
+              }
+            }}
+          />
+        </View>
+
+        {/* ═══ Eventos Participados ═══ */}
+        {profile.events && profile.events.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Eventos Participados</Text>
+            {profile.events.map((event, index) => (
+              <View key={index} style={styles.eventCard}>
+                <View style={styles.eventThumbnail} />
+                <View style={styles.eventInfo}>
+                  <Text style={styles.eventCategory}>
+                    {event.category.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                  </Text>
+                  <Text style={styles.eventTitle}>{event.title}</Text>
+                  <Text style={styles.eventMeta}>
+                    {event.organization} · {event.date}
+                  </Text>
+                  <View style={styles.eventBadges}>
+                    <View style={styles.eventStatusBadge}>
+                      <Text style={styles.eventStatusText}>
+                        {event.status === 'concluído' ? 'Concluído' : 'Em andamento'}
+                      </Text>
+                    </View>
+                    <View style={styles.eventHoursBadge}>
+                      <Text style={styles.eventHoursText}>{event.hours}h</Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
+
+      {/* ═══ Image Viewer Modal ═══ */}
+      <ImageViewer
+        visible={viewerVisible}
+        imageUrl={viewerUrl}
+        onClose={() => setViewerVisible(false)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+  },
+
+  // ── Loading ──
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: colors.neutral.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  loadingText: {
+    ...typography.body,
+    color: colors.text.secondary,
+    marginTop: 12,
+  },
+  errorBanner: {
+    ...typography.body,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: 16,
+    marginBottom: 20,
+  },
+  retryButton: {
+    backgroundColor: colors.brand.gold,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: radius.sm,
+  },
+  retryButtonText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 15,
+    color: colors.neutral.white,
+  },
+
+  // ── Header ──
+  header: {
+    backgroundColor: colors.brand.navy,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 50,
+    paddingBottom: 14,
+  },
+  headerBackButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 18,
+    color: colors.neutral.white,
+  },
+  headerSpacer: {
+    width: 36,
+  },
+
+  // ── Scroll ──
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 40,
+  },
+
+  // ── Banner ──
+  bannerContainer: {
+    width: '100%',
+    height: 168,
+  },
+  bannerImage: {
+    width: '100%',
+    height: 168,
+  },
+  bannerPlaceholder: {
+    backgroundColor: '#2a3754',
+  },
+
+  // ── Avatar ──
+  avatarWrapper: {
+    alignItems: 'center',
+    marginTop: -44,
+  },
+  avatarOuter: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    borderWidth: 4,
+    borderColor: colors.neutral.white,
+    overflow: 'hidden',
+  },
+  avatarImage: {
+    width: '100%',
+    height: '100%',
+  },
+  avatarPlaceholder: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colors.brand.gold,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarInitial: {
+    fontFamily: typography.h1.fontFamily,
+    fontSize: 36,
+    color: colors.neutral.white,
+  },
+
+  // ── Share Button ──
+  shareButton: {
+    position: 'absolute',
+    top: 50,
+    right: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    backgroundColor: colors.neutral.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+  },
+
+  // ── Card ──
+  card: {
+    marginHorizontal: 20,
+    marginTop: 12,
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.md,
+    padding: 20,
+    ...shadows.card,
+  },
+  name: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 22,
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  courseInfo: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: colors.accent.lightBg,
+    borderWidth: 1,
+    borderColor: colors.brand.gold,
+    borderRadius: radius.round,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    marginTop: 10,
+  },
+  badgeEmoji: {
+    fontSize: 11,
+    marginRight: 4,
+  },
+  badgeText: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 11,
+    color: colors.brand.gold,
+  },
+
+  // ── Progress ──
+  progressSection: {
+    marginTop: 20,
+  },
+  progressHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  progressLabel: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+  },
+  progressValue: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+  },
+  progressBarBg: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#e5e7eb',
+    overflow: 'hidden',
+  },
+  progressBarFill: {
+    height: '100%',
+    backgroundColor: colors.brand.gold,
+    borderRadius: 3,
+  },
+
+  // ── Stats ──
+  statsRow: {
+    flexDirection: 'row',
+    marginTop: 16,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.neutral.border,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statNumber: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 22,
+    color: colors.text.primary,
+  },
+  statLabel: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 11,
+    color: colors.text.secondary,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    backgroundColor: colors.neutral.border,
+  },
+
+  // ── Sections ──
+  section: {
+    marginHorizontal: 20,
+    marginTop: 24,
+  },
+  sectionTitle: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 16,
+    color: colors.text.primary,
+    marginBottom: 12,
+  },
+  bioText: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 14,
+    color: colors.text.info,
+    lineHeight: 22,
+  },
+
+  // ── Chips ──
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    backgroundColor: colors.accent.lightBg,
+    borderWidth: 1,
+    borderColor: colors.brand.gold,
+    borderRadius: radius.round,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+  },
+  chipText: {
+    fontFamily: typography.label.fontFamily,
+    fontSize: 13,
+    color: colors.brand.gold,
+  },
+
+  // ── Academic ──
+  academicRows: {
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.md,
+    ...shadows.card,
+  },
+  academicRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.border,
+  },
+  academicRowLast: {
+    borderBottomWidth: 0,
+  },
+  academicLabel: {
+    fontFamily: typography.body.fontFamily,
+    fontSize: 13,
+    color: colors.text.secondary,
+  },
+  academicValue: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 13,
+    color: colors.text.primary,
+  },
+
+  // ── Events ──
+  eventCard: {
+    flexDirection: 'row',
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.md,
+    padding: 12,
+    marginBottom: 10,
+    ...shadows.card,
+  },
+  eventThumbnail: {
+    width: 68,
+    height: 68,
+    borderRadius: 10,
+    backgroundColor: colors.accent.lightBg,
+    marginRight: 12,
+  },
+  eventInfo: {
+    flex: 1,
+  },
+  eventCategory: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 11,
+    color: colors.brand.gold,
+    marginBottom: 2,
+  },
+  eventTitle: {
+    fontFamily: typography.button.fontFamily,
+    fontSize: 14,
+    color: colors.text.primary,
+    marginBottom: 4,
+  },
+  eventMeta: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 12,
+    color: colors.text.secondary,
+  },
+  eventBadges: {
+    flexDirection: 'row',
+    marginTop: 6,
+    gap: 8,
+  },
+  eventStatusBadge: {
+    backgroundColor: colors.accent.lightBg,
+    borderRadius: radius.round,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderWidth: 1,
+    borderColor: colors.accent.subtleBorder,
+  },
+  eventStatusText: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 10,
+    color: colors.brand.gold,
+  },
+  eventHoursBadge: {
+    backgroundColor: '#e8f5e9',
+    borderRadius: radius.round,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  eventHoursText: {
+    fontFamily: typography['body-sm'].fontFamily,
+    fontSize: 10,
+    color: colors.success,
+  },
+
+  bottomSpacer: {
+    height: 32,
+  },
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -379,6 +379,25 @@ export async function getStudentProfile(token: string): Promise<ProfileData> {
 }
 
 /**
+ * Fetch another student's public profile (no email/matricula).
+ * GET /students/<userId>/
+ */
+export async function getStudentPublicProfile(
+  token: string,
+  userId: string,
+): Promise<ProfileData> {
+  const url = apiUrl(`/students/${userId}/`);
+  const response = await fetch(url, {
+    headers: { ...authHeaders(token) },
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to fetch profile', data, response.status);
+  }
+  return data as ProfileData;
+}
+
+/**
  * Update the authenticated student's profile.
  * PATCH /students/me/update/
  */
@@ -572,6 +591,25 @@ export interface OrgProfileData {
  */
 export async function getOrgProfile(token: string): Promise<OrgProfileData> {
   const url = apiUrl('/organizations/me/');
+  const response = await fetch(url, {
+    headers: { ...authHeaders(token) },
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError('Failed to fetch org profile', data, response.status);
+  }
+  return data as OrgProfileData;
+}
+
+/**
+ * Fetch an organization's public profile (no email/cnpj/telefone/nome_responsavel).
+ * GET /organizations/<orgId>/
+ */
+export async function getOrgPublicProfile(
+  token: string,
+  orgId: string,
+): Promise<OrgProfileData> {
+  const url = apiUrl(`/organizations/${orgId}/`);
   const response = await fetch(url, {
     headers: { ...authHeaders(token) },
   });


### PR DESCRIPTION
## Summary

Implements public profiles for students and organizations (S4 — Foundational).

### What was done

- **Backend**: New public endpoints `GET /api/v1/students/<uuid:pk>/` and `GET /api/v1/organizations/<uuid:pk>/` (IsAuthenticated, any role). Fields like email, matricula, CNPJ, telefone, and nome_responsavel are excluded from public views. Only approved orgs are visible (404 for pending/rejected). Added `organization.user_id` to opportunity payload for profile navigation.
- **Frontend**: Two new screens — `PublicStudentProfileScreen` and `PublicOrgProfileScreen` — reusing the layout of the owner screens but read-only (no edit/logout). Tap navigation wired from OpportunityCard, HomeScreen, and OpportunityDetailScreen.

### Commits (5)

| # | Commit | Description |
|---|--------|-------------|
| 1 | `c8f8443` | feat(profiles): add public profile routes and navigation config |
| 2 | `383b330` | feat(profiles): add public profile views, serializer fields, and API fetchers |
| 3 | `96eca1e` | feat(profiles): add public profile screens and tap navigation links |
| 4 | `e520198` | test(profiles): add public profile privacy and visibility tests |
| 5 | `f76c612` | docs: update API reference and gotchas for public profiles |

### Linked Issues

- Closes #119 (US 2.13 / RF23 — Ver Perfil do Estudante)
- Closes #111 (US 2.12 / RF22 — Ver Perfil da Organização)

### Foundational Contract

S1, S5, and S6 depend on the routes and endpoints defined here. Merge S4 first to make navigation taps functional across all sessions.