### PR TITLE
style: ajusta NotificationsScreen para seguir protótipo Figma (issue #25)

### DIFF
--- a/frontend/src/screens/NotificationsScreen.tsx
+++ b/frontend/src/screens/NotificationsScreen.tsx
@@ -1,9 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import React, { useCallback, useState } from 'react';
+import { LinearGradient } from 'expo-linear-gradient';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  FlatList,
+  SectionList,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -29,7 +30,7 @@ function iconForType(type: NotificationData['type']): React.ComponentProps<typeo
   }
 }
 
-function colorForType(type: NotificationData['type']): string {
+function iconColorForType(type: NotificationData['type']): string {
   switch (type) {
     case 'application_approved': return colors.success;
     case 'application_rejected': return '#9b1c1c';
@@ -37,23 +38,32 @@ function colorForType(type: NotificationData['type']): string {
   }
 }
 
+function iconBgForType(type: NotificationData['type']): string {
+  switch (type) {
+    case 'application_approved': return '#ebf7f1';
+    case 'application_rejected': return '#fdecea';
+    case 'new_application':      return colors.accent.lightBg;
+  }
+}
+
 function formatDate(iso: string): string {
   try {
     const d = new Date(iso);
-    const now = Date.now();
-    const diffMs = now - d.getTime();
+    const diffMs = Date.now() - d.getTime();
     const diffMin = Math.floor(diffMs / 60000);
-    if (diffMin < 1)   return 'Agora';
-    if (diffMin < 60)  return `${diffMin} min atrás`;
+    if (diffMin < 1)  return 'Agora';
+    if (diffMin < 60) return `${diffMin} min atrás`;
     const diffH = Math.floor(diffMin / 60);
-    if (diffH < 24)    return `${diffH}h atrás`;
+    if (diffH < 24)   return `${diffH}h atrás`;
     const diffD = Math.floor(diffH / 24);
-    if (diffD < 7)     return `${diffD}d atrás`;
+    if (diffD < 7)    return `${diffD}d atrás`;
     return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' });
   } catch {
     return '';
   }
 }
+
+type Section = { title: string; data: NotificationData[] };
 
 export default function NotificationsScreen() {
   const navigation = useNavigation<any>();
@@ -106,56 +116,87 @@ export default function NotificationsScreen() {
     }
   };
 
+  const sections = useMemo<Section[]>(() => {
+    const unread = notifications.filter(n => !n.is_read);
+    const read   = notifications.filter(n => n.is_read);
+    const result: Section[] = [];
+    if (unread.length) result.push({ title: 'Novas', data: unread });
+    if (read.length)   result.push({ title: 'Anteriores', data: read });
+    return result;
+  }, [notifications]);
+
+  const unreadLabel = unreadCount === 1 ? '1 não lida' : `${unreadCount} não lidas`;
+
   const renderCard = ({ item }: { item: NotificationData }) => (
     <TouchableOpacity
       style={[styles.card, !item.is_read && styles.cardUnread]}
       onPress={() => handleRead(item)}
       activeOpacity={0.75}
     >
-      <View style={[styles.typeIconWrap, { backgroundColor: colorForType(item.type) + '18' }]}>
-        <Ionicons name={iconForType(item.type)} size={20} color={colorForType(item.type)} />
+      <View style={[styles.iconWrap, { backgroundColor: iconBgForType(item.type) }]}>
+        <Ionicons name={iconForType(item.type)} size={18} color={iconColorForType(item.type)} />
       </View>
       <View style={styles.cardBody}>
-        <Text style={styles.cardTitle}>{item.title}</Text>
-        {item.opportunity_title ? (
-          <Text style={styles.cardOpportunity} numberOfLines={1}>{item.opportunity_title}</Text>
-        ) : null}
+        <View style={styles.titleRow}>
+          <Text style={[styles.cardTitle, item.is_read && styles.cardTitleRead]} numberOfLines={1}>
+            {item.title}
+          </Text>
+          {!item.is_read && <View style={styles.unreadDot} />}
+        </View>
         <Text style={styles.cardMessage} numberOfLines={2}>{item.message}</Text>
         <Text style={styles.cardDate}>{formatDate(item.created_at)}</Text>
       </View>
-      {!item.is_read && <View style={styles.unreadDot} />}
     </TouchableOpacity>
+  );
+
+  const renderSectionHeader = ({ section }: { section: Section }) => (
+    <Text style={styles.sectionLabel}>{section.title}</Text>
   );
 
   return (
     <View style={styles.container}>
-      {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color="#fff" />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Notificações</Text>
-        {unreadCount > 0 ? (
-          <TouchableOpacity onPress={handleMarkAllAsRead} style={styles.markAllButton}>
-            <Text style={styles.markAllText}>Marcar todas</Text>
-          </TouchableOpacity>
-        ) : (
-          <View style={styles.markAllButton} />
-        )}
-      </View>
+      <LinearGradient
+        colors={[colors.header.gradientFrom, colors.header.gradientTo]}
+        style={[styles.header, { paddingTop: insets.top + 12 }]}
+        start={{ x: 0.15, y: 0 }}
+        end={{ x: 0.85, y: 1 }}
+      >
+        <View style={styles.ringTopRight} />
+        <View style={styles.ringBottomLeft} />
 
-      {/* Content */}
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+            <Ionicons name="arrow-back" size={18} color="#fff" />
+          </TouchableOpacity>
+          <View style={styles.headerCenter}>
+            {unreadCount > 0 && (
+              <Text style={styles.headerSubtitle}>{unreadLabel.toUpperCase()}</Text>
+            )}
+            <Text style={styles.headerTitle}>Notificações</Text>
+          </View>
+          <View style={styles.headerRightSpacer} />
+        </View>
+
+        {unreadCount > 0 && (
+          <TouchableOpacity onPress={handleMarkAllAsRead} style={styles.markAllWrap}>
+            <Text style={styles.markAllText}>Marcar todas como lidas</Text>
+          </TouchableOpacity>
+        )}
+      </LinearGradient>
+
       {loading ? (
         <View style={styles.center}>
           <ActivityIndicator size="large" color={colors.brand.navy} />
         </View>
       ) : (
-        <FlatList
-          data={notifications}
+        <SectionList
+          sections={sections}
           keyExtractor={item => item.id}
           renderItem={renderCard}
+          renderSectionHeader={renderSectionHeader}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
+          stickySectionHeadersEnabled={false}
           ListEmptyComponent={
             <View style={styles.center}>
               <Ionicons name="notifications-off-outline" size={48} color={colors.text.secondary} />
@@ -173,59 +214,116 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.neutral.bg,
   },
+  header: {
+    paddingHorizontal: 20,
+    paddingBottom: 14,
+    overflow: 'hidden',
+  },
+  ringTopRight: {
+    position: 'absolute',
+    right: -10,
+    top: -34,
+    width: 140,
+    height: 140,
+    borderRadius: 70,
+    borderWidth: 1,
+    borderColor: 'rgba(212,129,58,0.14)',
+  },
+  ringBottomLeft: {
+    position: 'absolute',
+    left: -26,
+    bottom: -10,
+    width: 104,
+    height: 104,
+    borderRadius: 52,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.05)',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  headerCenter: {
+    flex: 1,
+    gap: 3,
+  },
+  headerSubtitle: {
+    fontFamily: fontFamilies.dmSansMedium,
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.45)',
+    letterSpacing: 0.88,
+  },
+  headerTitle: {
+    fontFamily: fontFamilies.playfairBold,
+    fontSize: 21,
+    color: '#fff',
+    lineHeight: 26,
+  },
+  headerRightSpacer: {
+    width: 36,
+    flexShrink: 0,
+  },
+  markAllWrap: {
+    alignSelf: 'flex-end',
+    marginTop: 8,
+  },
+  markAllText: {
+    fontFamily: fontFamilies.dmSansSemiBold,
+    fontSize: 12,
+    color: '#f0b070',
+  },
   center: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingTop: 60,
   },
-  header: {
-    backgroundColor: colors.brand.navy,
-    paddingBottom: 20,
-    paddingHorizontal: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  backButton: {
-    padding: 4,
-  },
-  headerTitle: {
-    fontFamily: fontFamilies.playfairBold,
-    fontSize: 18,
-    color: '#fff',
-  },
-  markAllButton: {
-    minWidth: 90,
-    alignItems: 'flex-end',
-  },
-  markAllText: {
-    fontFamily: fontFamilies.dmSansMedium,
-    fontSize: 13,
-    color: colors.brand.gold,
-  },
   list: {
-    padding: 16,
-    gap: 10,
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 24,
+  },
+  sectionLabel: {
+    fontFamily: fontFamilies.dmSansBold,
+    fontSize: 11,
+    color: colors.text.secondary,
+    letterSpacing: 0.44,
+    textTransform: 'uppercase',
+    paddingHorizontal: 4,
+    paddingTop: 4,
+    marginBottom: 10,
   },
   card: {
-    backgroundColor: '#fff',
-    borderRadius: 14,
-    padding: 14,
+    backgroundColor: colors.neutral.white,
+    borderRadius: 16,
+    padding: 15,
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: 12,
     borderWidth: 1,
-    borderColor: colors.neutral.border,
+    borderColor: '#ece7dc',
+    marginBottom: 10,
   },
   cardUnread: {
-    backgroundColor: '#eef2ff',
-    borderColor: 'rgba(99,102,241,0.2)',
+    backgroundColor: '#f4f7fc',
+    borderColor: '#dde6f3',
   },
-  typeIconWrap: {
+  iconWrap: {
     width: 40,
     height: 40,
-    borderRadius: 20,
+    borderRadius: 9999,
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
@@ -234,34 +332,37 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 3,
   },
-  cardTitle: {
-    fontFamily: fontFamilies.dmSansSemiBold,
-    fontSize: 14,
-    color: colors.text.primary,
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
-  cardOpportunity: {
-    fontFamily: fontFamilies.dmSansMedium,
-    fontSize: 12,
-    color: colors.brand.gold,
+  cardTitle: {
+    flex: 1,
+    fontFamily: fontFamilies.dmSansBold,
+    fontSize: 13.5,
+    color: colors.text.primary,
+    lineHeight: 20,
+  },
+  cardTitleRead: {
+    fontFamily: fontFamilies.dmSansSemiBold,
   },
   cardMessage: {
     fontFamily: fontFamilies.dmSansRegular,
-    fontSize: 13,
-    color: colors.text.info,
-    lineHeight: 18,
+    fontSize: 12.5,
+    color: '#5f6b82',
+    lineHeight: 17.5,
   },
   cardDate: {
     fontFamily: fontFamilies.dmSansRegular,
     fontSize: 11,
-    color: colors.text.secondary,
-    marginTop: 2,
+    color: '#9aa3b5',
   },
   unreadDot: {
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#6366f1',
-    marginTop: 6,
+    backgroundColor: colors.brand.gold,
     flexShrink: 0,
   },
   emptyText: {


### PR DESCRIPTION
## Resumo

- Redesenha o header: `LinearGradient` com anéis decorativos, subtítulo "X não lidas" e link "Marcar todas como lidas" na base do header — fiel ao Figma (node `647:300`)
- Troca `FlatList` por `SectionList` com seções **Novas** / **Anteriores** (unread vs read)
- Corrige cores dos cards: fundo `#f4f7fc`/borda `#dde6f3` para não lidos; `#fff`/`#ece7dc` para lidos
- Corrige ponto indicador de não lido: indigo → `colors.brand.gold`
- Corrige background dos ícones por tipo: verde (`#ebf7f1`) aprovado, vermelho (`#fdecea`) recusado, dourado para nova candidatura
- Toda lógica de fetch/markAsRead/markAllAsRead preservada sem alteração

## Arquivos alterados

- `frontend/src/screens/NotificationsScreen.tsx`

## Closes

Closes #25