### PR TITLE
feat: Minhas Candidaturas — redesign per Figma prototype (issue #86 / US2.11)

### DIFF
--- a/backend/applications/serializers.py
+++ b/backend/applications/serializers.py
@@ -22,9 +22,18 @@ class ApplicationCreateSerializer(serializers.ModelSerializer):
 
 
 class ApplicationOpportunitySummarySerializer(serializers.ModelSerializer):
+    organization = serializers.SerializerMethodField()
+
     class Meta:
         model = Opportunity
-        fields = ["id", "title", "status"]
+        fields = ["id", "title", "status", "organization"]
+
+    def get_organization(self, obj):
+        org = obj.organization
+        return {
+            "user_id": str(org.user_id),
+            "razao_social": org.razao_social,
+        }
 
 
 class ApplicationListSerializer(serializers.ModelSerializer):

--- a/frontend/src/screens/student/MyApplicationsScreen.tsx
+++ b/frontend/src/screens/student/MyApplicationsScreen.tsx
@@ -1,29 +1,25 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { LinearGradient } from 'expo-linear-gradient';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
+  Modal,
+  RefreshControl,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
-  RefreshControl,
 } from 'react-native';
 
+import NotificationBell from '../../components/NotificationBell';
 import { useAuth } from '../../context/AuthContext';
 import { getMyApplications } from '../../services/applications';
 import { colors } from '../../theme/colors';
-import { fontFamilies } from '../../theme/typography';
 import { radius } from '../../theme/spacing';
+import { fontFamilies } from '../../theme/typography';
 
-const STATUS_LABELS: Record<string, string> = {
-  
-  pending: 'Aguardando avaliação',
-  approved: 'Aprovada',
-  rejected: 'Rejeitada',
-  cancelled: 'Cancelada',
-};
 type FilterTab = 'all' | 'pending' | 'approved' | 'rejected' | 'cancelled';
 
 const TABS: { key: FilterTab; label: string }[] = [
@@ -34,13 +30,22 @@ const TABS: { key: FilterTab; label: string }[] = [
   { key: 'cancelled', label: 'Canceladas' },
 ];
 
+const STATUS_CONFIG: Record<string, { label: string; bg: string; color: string }> = {
+  pending:   { label: 'Aguardando', bg: '#fbf3e3', color: '#b5791f' },
+  approved:  { label: 'Aprovada',   bg: '#ebf7f1', color: '#1d7a4a' },
+  rejected:  { label: 'Rejeitada',  bg: '#fdecea', color: '#c0392b' },
+  cancelled: { label: 'Cancelada',  bg: '#eef0f3', color: colors.text.secondary },
+};
+
+const MONTHS = ['jan','fev','mar','abr','mai','jun','jul','ago','set','out','nov','dez'];
+
 interface ApplicationItem {
   id: string;
-  opportunity: { 
-    id: string; 
-    title: string; 
-    status: string; 
-    organization: { name: string };
+  opportunity: {
+    id: string;
+    title: string;
+    status: string;
+    organization: { user_id: string; razao_social: string };
   };
   status: string;
   created_at: string;
@@ -49,7 +54,9 @@ interface ApplicationItem {
 function formatDate(value?: string): string {
   if (!value) return '';
   const d = value.slice(0, 10).split('-');
-  return d.length === 3 ? `${d[2]}/${d[1]}/${d[0]}` : value;
+  if (d.length !== 3) return value;
+  const month = MONTHS[parseInt(d[1], 10) - 1] ?? d[1];
+  return `${parseInt(d[2], 10)} ${month} ${d[0]}`;
 }
 
 export default function MyApplicationsScreen() {
@@ -59,6 +66,7 @@ export default function MyApplicationsScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<FilterTab>('all');
   const [refreshing, setRefreshing] = useState(false);
+  const [cancelTarget, setCancelTarget] = useState<ApplicationItem | null>(null);
 
   const load = useCallback(async () => {
     if (!accessToken) return;
@@ -78,23 +86,20 @@ export default function MyApplicationsScreen() {
     setRefreshing(false);
   }, [load]);
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  useEffect(() => { load(); }, [load]);
 
-  const filteredItems = useMemo(() => {
-  if (activeTab === 'all') return items;
-  return items.filter((item) => item.status === activeTab);
-}, [items, activeTab]);
+  const filteredItems = useMemo(
+    () => activeTab === 'all' ? items : items.filter(i => i.status === activeTab),
+    [items, activeTab],
+  );
 
-const tabCounts = useMemo(() => {
-  const counts: Record<string, number> = { all: items.length };
-  for (const tab of TABS) {
-    if (tab.key === 'all') continue;
-    counts[tab.key] = items.filter((item) => item.status === tab.key).length;
-  }
-  return counts;
-}, [items]);
+  const tabCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: items.length };
+    for (const tab of TABS) {
+      if (tab.key !== 'all') counts[tab.key] = items.filter(i => i.status === tab.key).length;
+    }
+    return counts;
+  }, [items]);
 
   if (isLoading) {
     return (
@@ -106,157 +111,330 @@ const tabCounts = useMemo(() => {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity testID="back-button" onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={22} color={colors.brand.navy} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Minhas Candidaturas</Text>
-        <View style={{ width: 22 }} />
-      </View>
+      {/* Header */}
+      <LinearGradient colors={['#1a2744', '#111c38', '#0f1729']} style={styles.header}>
+        <View pointerEvents="none" style={styles.ringTopRight} />
+        <View pointerEvents="none" style={styles.ringBottomLeft} />
+        <View style={styles.headerRow}>
+          <TouchableOpacity
+            testID="back-button"
+            style={styles.glassBtn}
+            onPress={() => navigation.goBack()}
+            activeOpacity={0.7}
+          >
+            <Ionicons name="arrow-back" size={18} color="#fff" />
+          </TouchableOpacity>
 
-   <View style={styles.tabsRow}>
+          <View style={styles.headerText}>
+            <Text style={styles.headerSubtitle}>ACOMPANHE SEUS PROCESSOS</Text>
+            <Text style={styles.headerTitle}>
+              {'Minhas '}
+              <Text style={styles.headerTitleAccent}>candidaturas</Text>
+            </Text>
+          </View>
+
+          <NotificationBell
+            iconSize={18}
+            iconColor="#fff"
+            containerStyle={styles.glassBtn}
+            onNavigate={() => navigation.navigate('Notifications')}
+          />
+        </View>
+      </LinearGradient>
+
+      {/* Filter tabs */}
+      <View style={styles.tabsRow}>
         <FlatList
           data={TABS}
           horizontal
           showsHorizontalScrollIndicator={false}
-          refreshControl={
-          <RefreshControl 
-          refreshing={refreshing}
-          onRefresh={onRefresh}
-          colors={[colors.brand.navy]}
-          />}
-          keyExtractor={(tab) => tab.key}
+          keyExtractor={tab => tab.key}
           contentContainerStyle={styles.tabsContent}
-          renderItem={({ item: tab }) => (
-            <TouchableOpacity
-              testID={`tab-${tab.key}`}
-              style={[styles.tab, activeTab === tab.key && styles.activeTab]}
-              onPress={() => setActiveTab(tab.key)}
-            >
-              <Text style={[styles.tabLabel, activeTab === tab.key && styles.activeTabLabel]}>
-                {tab.label} · {tabCounts[tab.key] ?? 0}
-              </Text>
-            </TouchableOpacity>
-          )}
+          renderItem={({ item: tab }) => {
+            const active = activeTab === tab.key;
+            return (
+              <TouchableOpacity
+                testID={`tab-${tab.key}`}
+                style={[styles.tab, active && styles.activeTab]}
+                onPress={() => setActiveTab(tab.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.tabLabel, active && styles.activeTabLabel]}>
+                  {tab.label}
+                </Text>
+                <View style={[styles.tabBadge, active && styles.activeTabBadge]}>
+                  <Text style={[styles.tabBadgeText, active && styles.activeTabBadgeText]}>
+                    {tabCounts[tab.key] ?? 0}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          }}
         />
       </View>
 
+      {/* Cards */}
       <FlatList
         data={filteredItems}
-        keyExtractor={(item) => item.id}
+        keyExtractor={item => item.id}
         contentContainerStyle={styles.list}
-        renderItem={({ item }) => (
-          <TouchableOpacity
-            style={styles.card}
-            onPress={() => navigation.navigate('OpportunityDetail', { id: item.opportunity.id })}
-          >
-            <Text style={styles.cardTitle}>{item.opportunity.title}</Text>
-            <Text style={{ fontSize: 13, color: colors.text.secondary, marginBottom: 8 }}>
-              {item.opportunity.organization?.name}
-            </Text>
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[colors.brand.navy]} />
+        }
+        renderItem={({ item }) => {
+          const cfg = STATUS_CONFIG[item.status] ?? STATUS_CONFIG.pending;
+          const org = item.opportunity.organization;
+          const isPending = item.status === 'pending';
 
-            <View style={styles.cardMeta}>
-              <View style={styles.statusBadge}>
-                <Text style={styles.statusText}>
-                  {STATUS_LABELS[item.status] ?? item.status}
-                </Text>
+          return (
+            <View style={styles.card}>
+              <View style={styles.cardTop}>
+                <View style={[styles.statusBadge, { backgroundColor: cfg.bg }]}>
+                  <View style={[styles.statusDot, { backgroundColor: cfg.color }]} />
+                  <Text style={[styles.statusText, { color: cfg.color }]}>
+                    {cfg.label.toUpperCase()}
+                  </Text>
+                </View>
+
+                <Text style={styles.cardTitle}>{item.opportunity.title}</Text>
+
+                <TouchableOpacity
+                  onPress={org?.user_id
+                    ? () => navigation.navigate('PublicOrgProfile', { orgId: org.user_id })
+                    : undefined}
+                  activeOpacity={org?.user_id ? 0.6 : 1}
+                >
+                  <Text style={styles.cardOrg}>{org?.razao_social ?? ''}</Text>
+                </TouchableOpacity>
+
+                <View style={styles.dateRow}>
+                  <Ionicons name="calendar-outline" size={14} color={colors.text.secondary} />
+                  <Text style={styles.dateText}>Candidatura em {formatDate(item.created_at)}</Text>
+                </View>
               </View>
-              <Text style={styles.date}>Candidatura em {formatDate(item.created_at)}</Text>
-            </View>
 
-            {item.status === 'pending' && (
-              <TouchableOpacity 
-                style={{ marginTop: 12, padding: 8, backgroundColor: colors.neutral.border, borderRadius: radius.sm, alignItems: 'center' }}
-                onPress={() => {
-                  // Aqui você chama a função do endpoint de cancelamento (US2.9)
-                }}
-              >
-                <Text style={{ color: colors.text.primary, fontFamily: fontFamilies.dmSansSemiBold }}>
-                  Cancelar Candidatura
-                </Text>
-              </TouchableOpacity>
-            )}
-          </TouchableOpacity>
-        )}
+              <View style={styles.cardFooter}>
+                <TouchableOpacity
+                  style={[styles.footerBtn, styles.footerBtnOutline]}
+                  onPress={() => navigation.navigate('OpportunityDetail', { id: item.opportunity.id })}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.footerBtnOutlineText}>Ver vaga</Text>
+                </TouchableOpacity>
+
+                {isPending && (
+                  <TouchableOpacity
+                    style={[styles.footerBtn, styles.footerBtnCancel]}
+                    onPress={() => setCancelTarget(item)}
+                    activeOpacity={0.7}
+                  >
+                    <Ionicons name="close-circle-outline" size={15} color="#c0392b" />
+                    <Text style={styles.footerBtnCancelText}>Cancelar</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            </View>
+          );
+        }}
         ListEmptyComponent={
           <View testID="empty-state" style={styles.empty}>
-            <Ionicons name="document-text-outline" size={48} color={colors.text.secondary} />
-            <Text style={styles.emptyText}>
+            <View style={styles.emptyIconWrap}>
+              <Ionicons name="document-text-outline" size={44} color={colors.text.secondary} />
+            </View>
+            <Text style={styles.emptyTitle}>
               {items.length === 0
-                ? 'Você ainda não se candidatou a nenhuma vaga'
+                ? 'Você ainda não tem candidaturas'
                 : 'Nenhuma candidatura com esse status'}
             </Text>
             {items.length === 0 && (
-    <TouchableOpacity 
-      style={{ marginTop: 16, paddingVertical: 10, paddingHorizontal: 20, backgroundColor: colors.brand.navy, borderRadius: radius.md }}
-      onPress={() => navigation.navigate('SearchOpportunities')} // Substitua pelo nome exato da sua rota de busca de vagas
-    >
-      <Text style={{ color: colors.neutral.white, fontFamily: fontFamilies.dmSansSemiBold }}>
-        Buscar vagas
-      </Text>
-    </TouchableOpacity>
-  )}
+              <Text style={styles.emptySubtitle}>
+                Explore as vagas de voluntariado e candidate-se às que combinam com você. Elas aparecerão aqui.
+              </Text>
+            )}
+            {items.length === 0 && (
+              <TouchableOpacity
+                style={styles.emptyBtn}
+                onPress={() => navigation.navigate('SearchOpportunities')}
+                activeOpacity={0.8}
+              >
+                <Ionicons name="search-outline" size={16} color={colors.neutral.white} />
+                <Text style={styles.emptyBtnText}>Buscar vagas</Text>
+              </TouchableOpacity>
+            )}
           </View>
         }
       />
+
+      {/* Cancel confirmation modal */}
+      <Modal
+        visible={!!cancelTarget}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setCancelTarget(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalCard}>
+            <View style={styles.modalIconWrap}>
+              <Ionicons name="close-circle" size={28} color="#c0392b" />
+            </View>
+            <Text style={styles.modalTitle}>Cancelar candidatura?</Text>
+            <Text style={styles.modalBody}>
+              {'Tem certeza que deseja cancelar sua candidatura para '}
+              <Text style={styles.modalBodyBold}>{cancelTarget?.opportunity.title}</Text>
+              {'? Esta ação não pode ser desfeita.'}
+            </Text>
+            <View style={styles.modalBtns}>
+              <TouchableOpacity
+                style={[styles.modalBtn, styles.modalBtnBack]}
+                onPress={() => setCancelTarget(null)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.modalBtnBackText}>Voltar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalBtn, styles.modalBtnConfirm]}
+                onPress={() => {
+                  // ponytail: cancel API (US2.9) not implemented yet
+                  setCancelTarget(null);
+                }}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.modalBtnConfirmText}>Sim, cancelar</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.neutral.bg },
-  centered: {
-    flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.neutral.bg,
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.neutral.bg },
+
+  header: { paddingTop: 54, paddingBottom: 16, paddingHorizontal: 20, overflow: 'hidden' },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  glassBtn: {
+    width: 36, height: 36, borderRadius: 18,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)',
+    alignItems: 'center', justifyContent: 'center', flexShrink: 0,
   },
-  header: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingTop: 50, paddingBottom: 16, paddingHorizontal: 20,
-    backgroundColor: colors.neutral.white, borderBottomWidth: 1, borderBottomColor: colors.neutral.border,
+  headerText: { flex: 1, gap: 3 },
+  headerSubtitle: {
+    fontFamily: fontFamilies.dmSansMedium,
+    fontSize: 11, letterSpacing: 0.88, textTransform: 'uppercase',
+    color: 'rgba(255,255,255,0.45)',
   },
-  headerTitle: { fontFamily: fontFamilies.playfairBold, fontSize: 18, color: colors.text.primary },
-  list: { padding: 20, gap: 12, flexGrow: 1 },
-  card: {
-    backgroundColor: colors.neutral.white, borderRadius: radius.md, padding: 16,
-    borderWidth: 1, borderColor: colors.neutral.border, gap: 8,
+  headerTitle: { fontFamily: fontFamilies.playfairBold, fontSize: 21, color: '#fff' },
+  headerTitleAccent: { fontFamily: fontFamilies.playfairBoldItalic, fontSize: 21, color: '#f0b070' },
+  ringTopRight: {
+    position: 'absolute', top: -34, right: -30,
+    width: 140, height: 140, borderRadius: 70,
+    borderWidth: 1, borderColor: 'rgba(212,129,58,0.14)',
   },
+  ringBottomLeft: {
+    position: 'absolute', bottom: -20, left: -26,
+    width: 104, height: 104, borderRadius: 52,
+    borderWidth: 1, borderColor: 'rgba(255,255,255,0.05)',
+  },
+
   tabsRow: {
     backgroundColor: colors.neutral.white,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.neutral.border,
+    borderBottomWidth: 1, borderBottomColor: colors.neutral.border,
   },
-  tabsContent: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    gap: 8,
-  },
+  tabsContent: { paddingHorizontal: 16, paddingVertical: 10, gap: 8 },
   tab: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
+    flexDirection: 'row', alignItems: 'center', gap: 7,
+    paddingHorizontal: 13, height: 36,
     borderRadius: radius.round,
-    backgroundColor: colors.neutral.bg,
-    borderWidth: 1,
-    borderColor: colors.neutral.border,
+    backgroundColor: colors.neutral.white,
+    borderWidth: 1, borderColor: colors.neutral.border,
   },
-  activeTab: {
-    backgroundColor: colors.brand.navy,
-    borderColor: colors.brand.navy,
+  activeTab: { backgroundColor: colors.brand.navy, borderColor: colors.brand.navy },
+  tabLabel: { fontFamily: fontFamilies.dmSansMedium, fontSize: 13, color: colors.text.secondary },
+  activeTabLabel: { color: colors.neutral.white },
+  tabBadge: {
+    minWidth: 20, height: 16, borderRadius: radius.round,
+    backgroundColor: '#e8e0d0',
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5,
   },
-  tabLabel: {
-    fontFamily: fontFamilies.dmSansSemiBold,
-    fontSize: 12,
-    color: colors.text.secondary,
+  activeTabBadge: { backgroundColor: 'rgba(255,255,255,0.2)' },
+  tabBadgeText: { fontFamily: fontFamilies.dmSansBold, fontSize: 10, color: colors.text.secondary },
+  activeTabBadgeText: { color: colors.neutral.white },
+
+  list: { padding: 20, gap: 14, flexGrow: 1 },
+
+  card: {
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.lg,
+    borderWidth: 1, borderColor: colors.neutral.border,
+    overflow: 'hidden',
   },
-  activeTabLabel: {
-    color: colors.neutral.white,
-  },
-  cardTitle: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 15, color: colors.text.primary },
-  cardMeta: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 6 },
+  cardTop: { padding: 16, gap: 8 },
   statusBadge: {
-    backgroundColor: colors.accent.lightBg, borderRadius: radius.round,
+    flexDirection: 'row', alignItems: 'center', gap: 5,
+    alignSelf: 'flex-start',
     paddingHorizontal: 10, paddingVertical: 4,
+    borderRadius: radius.round,
   },
-  statusText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 11, color: colors.brand.gold },
-  date: { fontFamily: fontFamilies.dmSansRegular, fontSize: 12, color: colors.text.secondary },
-  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12, paddingTop: 60 },
-  emptyText: { fontFamily: fontFamilies.dmSansRegular, fontSize: 14, color: colors.text.secondary, textAlign: 'center' },
+  statusDot: { width: 6, height: 6, borderRadius: 3 },
+  statusText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 10, letterSpacing: 0.4 },
+  cardTitle: { fontFamily: fontFamilies.playfairBold, fontSize: 17, color: colors.text.primary },
+  cardOrg: { fontFamily: fontFamilies.dmSansRegular, fontSize: 13, color: colors.text.secondary },
+  dateRow: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  dateText: { fontFamily: fontFamilies.dmSansRegular, fontSize: 12.5, color: colors.text.secondary },
+
+  cardFooter: {
+    flexDirection: 'row', gap: 8,
+    borderTopWidth: 1, borderTopColor: '#ece7dc',
+    paddingHorizontal: 16, paddingVertical: 13,
+  },
+  footerBtn: {
+    flex: 1, height: 36, borderRadius: radius.sm,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6,
+  },
+  footerBtnOutline: { borderWidth: 1, borderColor: colors.brand.navy, backgroundColor: colors.neutral.white },
+  footerBtnOutlineText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 13, color: colors.brand.navy },
+  footerBtnCancel: { borderWidth: 1, borderColor: '#c0392b', backgroundColor: colors.neutral.white },
+  footerBtnCancelText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 13, color: '#c0392b' },
+
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16, paddingTop: 60, paddingHorizontal: 32 },
+  emptyIconWrap: {
+    width: 104, height: 104, borderRadius: 52,
+    backgroundColor: '#f0ece3',
+    alignItems: 'center', justifyContent: 'center',
+  },
+  emptyTitle: { fontFamily: fontFamilies.playfairBold, fontSize: 19, color: colors.text.primary, textAlign: 'center' },
+  emptySubtitle: { fontFamily: fontFamilies.dmSansRegular, fontSize: 13.5, color: colors.text.secondary, textAlign: 'center', lineHeight: 19.5 },
+  emptyBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    backgroundColor: colors.brand.navy,
+    paddingVertical: 13, paddingHorizontal: 26,
+    borderRadius: 10,
+  },
+  emptyBtnText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 13, color: colors.neutral.white },
+
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(13,20,36,0.55)', alignItems: 'center', justifyContent: 'center' },
+  modalCard: {
+    width: 322, backgroundColor: colors.neutral.white,
+    borderRadius: 22, paddingHorizontal: 22, paddingTop: 26, paddingBottom: 20,
+    alignItems: 'center', gap: 14,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 18 },
+    shadowOpacity: 0.28, shadowRadius: 22, elevation: 12,
+  },
+  modalIconWrap: {
+    width: 58, height: 58, borderRadius: 29,
+    backgroundColor: '#fdecea', alignItems: 'center', justifyContent: 'center',
+  },
+  modalTitle: { fontFamily: fontFamilies.playfairBold, fontSize: 19, color: colors.text.primary, textAlign: 'center' },
+  modalBody: { fontFamily: fontFamilies.dmSansRegular, fontSize: 13, color: colors.text.secondary, textAlign: 'center', lineHeight: 19.5, width: 278 },
+  modalBodyBold: { fontFamily: fontFamilies.dmSansBold },
+  modalBtns: { flexDirection: 'row', gap: 10, paddingTop: 6, width: 278 },
+  modalBtn: { flex: 1, height: 44, borderRadius: 10, alignItems: 'center', justifyContent: 'center' },
+  modalBtnBack: { borderWidth: 1, borderColor: colors.brand.navy, backgroundColor: colors.neutral.white },
+  modalBtnBackText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 13, color: colors.brand.navy },
+  modalBtnConfirm: { backgroundColor: '#c0392b' },
+  modalBtnConfirmText: { fontFamily: fontFamilies.dmSansSemiBold, fontSize: 13, color: colors.neutral.white },
 });


### PR DESCRIPTION
## Resumo

- **Backend:** expõe `organization.user_id` e `organization.razao_social` no serializer de listagem de candidaturas (`ApplicationOpportunitySummarySerializer`), permitindo exibir o nome da org e navegar ao perfil público.
- **Frontend:** redesenho completo de `MyApplicationsScreen` para bater com o protótipo Figma (fileKey `f6bQuVohTvZLF5WWPEbNob`, frame `647:2`).

### Mudanças de UI

| Elemento | Antes | Depois |
|---|---|---|
| Header | Barra branca simples | Gradiente navy com botões frosted-glass e título editorial |
| Tabs | Pill com `label · count` | Pill separado para badge de contagem |
| Cards | `borderRadius:12`, badge genérico | `borderRadius:20`, badge colorido por status + footer com ações |
| Data | `18/06/2026` | `18 jun 2026` (calendar icon) |
| Org | Texto plano sem tap | Tappable → `PublicOrgProfile` |
| Empty state | Ícone solto | Ícone em círculo `#f0ece3`, título Playfair, CTA button |
| Cancelar | Botão cinza inline | Footer button outline-red + modal de confirmação |

### Notas

- Cancel API (US2.9) ainda não implementada — botão abre modal de confirmação mas ação está stubbed com `// ponytail: cancel API (US2.9) not implemented yet`.
- `select_related("opportunity__organization")` já existia na view — sem impacto de query.
- 18/18 testes backend passando. TypeScript sem erros no arquivo alterado.

## Plano de teste

- [ ] Abrir "Minhas Candidaturas" com candidaturas em vários status → conferir layout vs Figma
- [ ] Tocar em cada tab de filtro → lista filtra corretamente
- [ ] Tocar no nome da org → navega para `PublicOrgProfile`
- [ ] Tocar em "Ver vaga" → navega para `OpportunityDetail`
- [ ] Candidatura pendente: botão "Cancelar" → modal aparece com título correto → "Voltar" fecha modal
- [ ] Pull-to-refresh funciona
- [ ] Estado vazio: nenhuma candidatura → ícone + texto + botão "Buscar vagas"
- [ ] Estado vazio filtrado: tab sem candidaturas → mensagem alternativa