### PR TITLE
feat: lista de candidatos com avatar e navegação para perfil (issue #24)

### DIFF
--- a/backend/applications/serializers.py
+++ b/backend/applications/serializers.py
@@ -37,13 +37,21 @@ class ApplicationListSerializer(serializers.ModelSerializer):
 
 
 class ApplicationStudentSummarySerializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(source="user.id", read_only=True)
     nome = serializers.CharField(source="user.nome")
     curso = serializers.CharField()
     universidade = serializers.CharField()
+    avatar_url = serializers.SerializerMethodField()
 
     class Meta:
         model = __import__("users.models", fromlist=["StudentProfile"]).StudentProfile
-        fields = ["nome", "curso", "universidade"]
+        fields = ["id", "nome", "curso", "universidade", "avatar_url"]
+
+    def get_avatar_url(self, obj):
+        request = self.context.get("request")
+        if obj.avatar and obj.avatar.name and request:
+            return request.build_absolute_uri(obj.avatar.url)
+        return None
 
 
 class ApplicationEvaluationSerializer(serializers.ModelSerializer):

--- a/backend/applications/tests/test_views.py
+++ b/backend/applications/tests/test_views.py
@@ -161,6 +161,17 @@ class TestOpportunityApplicationsList:
         resp = api_client.get(f"/api/v1/applications/opportunities/{opp.id}/")
         assert resp.status_code == 403
 
+    def test_student_fields_include_id_and_avatar_url(self, api_client, org, student_user):
+        opp = _opp(org)
+        Application.objects.create(student=student_user.student_profile, opportunity=opp)
+        api_client.force_authenticate(user=org.user)
+        resp = api_client.get(f"/api/v1/applications/opportunities/{opp.id}/")
+        assert resp.status_code == 200
+        student = resp.data[0]["student"]
+        assert str(student_user.id) == str(student["id"])
+        assert "avatar_url" in student
+        assert student["avatar_url"] is None  # sem avatar → null
+
 
 @pytest.mark.django_db
 class TestApplicationEvaluate:

--- a/backend/applications/views.py
+++ b/backend/applications/views.py
@@ -106,7 +106,9 @@ class OpportunityApplicationsViewSet(viewsets.GenericViewSet):
         applications = Application.objects.filter(opportunity=opportunity).select_related(
             "student__user"
         )
-        serializer = ApplicationEvaluationSerializer(applications, many=True)
+        serializer = ApplicationEvaluationSerializer(
+            applications, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
     def evaluate(self, request, pk=None):

--- a/frontend/src/screens/organization/OpportunityApplicantsScreen.tsx
+++ b/frontend/src/screens/organization/OpportunityApplicantsScreen.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  Image,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -91,6 +92,10 @@ export default function OpportunityApplicantsScreen() {
     }
   };
 
+  const goToProfile = (userId: string) => {
+    navigation.navigate('PublicStudentProfile', { userId });
+  };
+
   const filtered = applications.filter(a => a.status === activeTab);
 
   const renderCard = ({ item }: { item: Application }) => {
@@ -98,7 +103,15 @@ export default function OpportunityApplicantsScreen() {
     return (
       <View style={styles.card}>
         <View style={styles.cardHeader}>
-          <Ionicons name="person-circle-outline" size={40} color="#1a2744" />
+          <TouchableOpacity onPress={() => goToProfile(item.student.id)}>
+            {item.student.avatar_url ? (
+              <Image source={{ uri: item.student.avatar_url }} style={styles.avatar} />
+            ) : (
+              <View style={styles.avatarFallback}>
+                <Ionicons name="person" size={22} color="#7a8299" />
+              </View>
+            )}
+          </TouchableOpacity>
           <View style={{ flex: 1, marginLeft: 12 }}>
             <Text style={styles.studentName}>{item.student.nome}</Text>
             <Text style={styles.studentInfo}>{item.student.curso} · {item.student.universidade}</Text>
@@ -106,6 +119,12 @@ export default function OpportunityApplicantsScreen() {
               Inscrito em {new Date(item.created_at).toLocaleDateString('pt-BR')}
             </Text>
           </View>
+          <TouchableOpacity
+            style={styles.detailButton}
+            onPress={() => goToProfile(item.student.id)}
+          >
+            <Ionicons name="chevron-forward" size={18} color="#d4813a" />
+          </TouchableOpacity>
         </View>
 
         {isPending && (
@@ -235,6 +254,16 @@ const styles = StyleSheet.create({
     borderColor: '#ddd8ce',
   },
   cardHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 12 },
+  avatar: { width: 44, height: 44, borderRadius: 22 },
+  avatarFallback: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: '#f0eee9',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  detailButton: { padding: 4 },
   studentName: { fontSize: 15, fontWeight: 'bold', color: '#1a2744' },
   studentInfo: { fontSize: 13, color: '#3a4560', marginTop: 2 },
   studentDate: { fontSize: 12, color: '#7a8299', marginTop: 2 },

--- a/frontend/src/services/evaluations.ts
+++ b/frontend/src/services/evaluations.ts
@@ -1,9 +1,11 @@
 import { apiUrl } from '../config/api';
 
 export interface ApplicationStudent {
+  id: string;
   nome: string;
   curso: string;
   universidade: string;
+  avatar_url: string | null;
 }
 
 export interface Application {


### PR DESCRIPTION
## Resumo

Closes #24 — US2.8 / RF11 (refino de UI da tela de candidatos).

- **Backend:** `ApplicationStudentSummarySerializer` agora expõe `id` (UUID do User) e `avatar_url` (URI absoluta do avatar ou `null`). View passa `context={'request': request}` para resolver URI corretamente.
- **Frontend:** `OpportunityApplicantsScreen` exibe avatar circular do estudante com fallback Ionicon; tocar na foto ou no chevron navega para `PublicStudentProfile { userId }`. Interface `ApplicationStudent` atualizada com `id` e `avatar_url`.

## Dependência

Rota `PublicStudentProfile` é criada pela S4. Navegação já está wired; ficará funcional após merge de S4.

## Testes

- 18 testes backend passando (`applications/tests/`)
- Novo teste: `test_student_fields_include_id_and_avatar_url`
- TypeScript: sem erros nos arquivos alterados

## Test plan

- [ ] `pytest backend/applications/tests/` — 18 passed
- [ ] App: tela de candidatos exibe avatar (ou placeholder) para cada candidato
- [ ] Tocar na foto navega para tela de perfil público (funcional após S4)
- [ ] Tocar no chevron `>` navega para tela de perfil público (funcional após S4)
- [ ] Candidato sem avatar exibe ícone `person` em fundo cinza